### PR TITLE
ESWE-831 Update and clean build Gradle

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,6 +10,3 @@
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
-# Suppression for logback-classic and logback-core as we don't let third parties control our appenders.
-# See https://logback.qos.ch/news.html#1.3.12 for further information.
-CVE-2023-6378

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,26 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.10.1"
-  kotlin("plugin.spring") version "1.9.21"
-  kotlin("plugin.jpa") version "1.9.21"
-  id("name.remal.integration-tests") version "4.0.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.0"
+  kotlin("plugin.spring") version "2.0.0"
+  kotlin("plugin.jpa") version "2.0.0"
   id("jvm-test-suite")
   id("jacoco")
 }
 
-configurations {
-  implementation {
-    exclude(module = "commons-logging")
-    exclude(module = "log4j")
-  }
-  testImplementation { exclude(group = "org.junit.vintage") }
+dependencies {
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:2.1.1")
+  implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+  runtimeOnly("org.flywaydb:flyway-database-postgresql")
+  runtimeOnly("org.postgresql:postgresql:42.7.3")
+
+  developmentOnly("org.springframework.boot:spring-boot-devtools")
+
+  testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+  testImplementation("com.h2database:h2")
 }
 
 testing {
@@ -20,97 +28,40 @@ testing {
     val test by getting(JvmTestSuite::class) {
       useJUnitJupiter()
     }
-    val integrationTest by getting(JvmTestSuite::class) {
-      useJUnitJupiter()
+
+    register<JvmTestSuite>("integrationTest") {
       dependencies {
-        implementation(project())
+        testType.set(TestSuiteType.INTEGRATION_TEST)
+        kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
+        implementation("org.springframework.boot:spring-boot-starter-test")
+        implementation("io.jsonwebtoken:jjwt-impl:0.12.5")
+        implementation("io.jsonwebtoken:jjwt-jackson:0.12.5")
+        runtimeOnly("org.flywaydb:flyway-database-postgresql")
+        implementation("com.zaxxer:HikariCP:5.1.0")
+        implementation("com.h2database:h2")
       }
-      sourceSets["main"].apply {
-        kotlin.srcDir("${layout.buildDirectory}/src/main/kotlin")
-      }
-      sourceSets["integrationTest"].apply {
-        kotlin.srcDir("${layout.buildDirectory}/src/integrationTest/kotlin")
+
+      targets {
+        all {
+          testTask.configure {
+            shouldRunAfter(test)
+          }
+        }
       }
     }
   }
-}
-
-dependencies {
-  annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-  annotationProcessor("org.projectlombok:lombok:1.18.30")
-  testAnnotationProcessor("org.projectlombok:lombok:1.18.30")
-
-  implementation("org.springframework.boot:spring-boot-starter-aop")
-  implementation("org.springframework.boot:spring-boot-starter-validation")
-  implementation("org.springframework.boot:spring-boot-starter-jdbc")
-  implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-  implementation("org.springframework.boot:spring-boot-starter-security")
-  implementation("org.springframework.boot:spring-boot-starter-cache")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:2.1.1")
-
-  developmentOnly("org.springframework.boot:spring-boot-devtools")
-
-  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-
-  implementation("commons-codec:commons-codec:1.16.0")
-  implementation("io.swagger:swagger-annotations:1.6.12")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
-
-  implementation("org.apache.commons:commons-lang3:3.14.0")
-  implementation("commons-io:commons-io:2.15.1")
-  implementation("com.google.guava:guava:32.1.3-jre")
-
-  implementation("org.ehcache:ehcache:3.10.8")
-  implementation("com.zaxxer:HikariCP:5.1.0")
-  implementation("com.oracle.database.jdbc:ojdbc10:19.21.0.0")
-  implementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
-  implementation("org.hibernate.orm:hibernate-community-dialects")
-
-// Database dependencies
-  implementation("org.flywaydb:flyway-core")
-  runtimeOnly("org.postgresql:postgresql:42.4.0")
-  testImplementation("org.springframework.security:spring-security-test")
-  testImplementation("io.jsonwebtoken:jjwt-impl:0.12.3")
-  testImplementation("io.jsonwebtoken:jjwt-jackson:0.12.3")
-  testImplementation("org.mockito:mockito-inline:5.2.0")
-  testImplementation("io.mockk:mockk:1.13.9")
-  testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.0")
-  testImplementation("org.junit.jupiter:junit-jupiter")
-  testImplementation("org.testcontainers:localstack")
-
-  testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
-  testImplementation("io.kotest:kotest-assertions-core:5.8.0")
-  testImplementation("io.kotest:kotest-property:5.8.0")
-  testImplementation("com.h2database:h2")
-}
-
-kotlin {
-  jvmToolchain(21)
-}
-kotlin {
-  sourceSets["main"].apply {
-    kotlin.srcDir("${layout.buildDirectory}/generated/src/main/kotlin")
-  }
-}
-java {
-  sourceCompatibility = JavaVersion.VERSION_21
-  targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks {
-  withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-      jvmTarget = "21"
-    }
-    withType<JavaCompile> {
-      sourceCompatibility = "21"
-    }
+  withType<KotlinCompile> {
     named("check") {
       dependsOn(testing.suites.named("integrationTest"))
     }
+
     named("compileIntegrationTestKotlin") {
       dependsOn(named("copyAgent"))
     }
+
     named<JacocoReport>("jacocoTestReport") {
       dependsOn(named("check"))
       reports {
@@ -118,12 +69,13 @@ tasks {
         xml.required.set(true)
       }
     }
+
     finalizedBy(named("jacocoTestReport"))
     named("assemble") {
       doFirst {
         delete(
           fileTree(project.layout.buildDirectory.get())
-            .include("libs/*-plain.jar")
+            .include("libs/*-plain.jar"),
         )
       }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,1 @@
 rootProject.name = "hmpps-jobs-board-api"
-include("src:integrationTest")


### PR DESCRIPTION
Reviewed Gradle's build with the following changes:

- Upgraded HMPPS spring boot plugin to the last stable version (v6.0.0)
- Upgrade Kotlin Spring and JPA plugins to the last stable version (v2.0.0)
- Remove unnecessary plugins
- Remove unnecessary global dependencies
- Update global dependencies to the last stable version
- Modify the definition of the Integration test suite to align with Gradle's jvm-test-suite plugin documentation
- Remove unnecessary tasks and Kotlin definitions.
- Updated Trivignore file (Not sure if it is even necessary to be pushed to the repository)
- Removed unnecessary integration tests sources in Gradle's settings
