### PR TITLE
ESWE-831 Upgrade Helm dependencies to last stable versions

### DIFF
--- a/helm_deploy/hmpps-jobs-board-api/Chart.yaml
+++ b/helm_deploy/hmpps-jobs-board-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-jobs-board-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "2.9"
+    version: "3.3.1"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.4"
+    version: "1.8.0"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
The purpose of this PR is to update the following Helm dependencies of this project:

- generic-service
- generic-prometheus-alerts

 I'm using as a reference the HMPPS Helm chart releases page:

https://github.com/ministryofjustice/hmpps-helm-charts/releases