### PR TITLE
ESWE-831 Adds Helm database environment variables

### DIFF
--- a/helm_deploy/hmpps-jobs-board-api/values.yaml
+++ b/helm_deploy/hmpps-jobs-board-api/values.yaml
@@ -30,6 +30,11 @@ generic-service:
   namespace_secrets:
     hmpps-jobs-board-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+    rds-postgresql-instance-output:
+      DATABASE_USERNAME: "database_username"
+      DATABASE_PASSWORD: "database_password"
+      DATABASE_NAME: "database_name"
+      DATABASE_ENDPOINT: "rds_instance_endpoint"
 
   allowlist:
     groups:


### PR DESCRIPTION
After creating the Dev database the app needs to inject the database details from the secrets stored on the namespace.