### PR TITLE
[ESWE-831] Improve development config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - hmpps
     container_name: hmpps-jobs-board-api
     ports:
-      - "8081:8080"
+      - "8080:8080"
     depends_on:
       - job-board-db
     healthcheck:
@@ -26,7 +26,7 @@ services:
     networks:
       - hmpps
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=job-board
       - POSTGRES_USER=job-board

--- a/src/main/resources/application-developer.yml
+++ b/src/main/resources/application-developer.yml
@@ -2,10 +2,10 @@ server:
   shutdown: immediate
   port: 8080
 
-#api:
-#  base:
-#    url:
-#      oauth1: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+api:
+  base:
+    url:
+      oauth: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 management.endpoint:
   health.cache.time-to-live: 0
@@ -33,7 +33,6 @@ spring:
       validationTimeout: 500
 
   flyway:
-    initOnMigrate: true
     baselineOnMigrate: true
     validateMigrationNaming: true
     enabled: true


### PR DESCRIPTION
The following PR improves some aspects of local development:

- Set standard ports for the app and the database in the Docker compose script
- Adds Dev auth URL for local development
- Deletes deprecated FlyWay _initOnMigrate_ attribute