### PR TITLE
[ESWE-831] Removes unnecessary JPA Springboot configuration

### DIFF
--- a/src/main/resources/application-developer.yml
+++ b/src/main/resources/application-developer.yml
@@ -13,15 +13,6 @@ management.endpoint:
 spring:
   devtools:
     add-properties: true
-  jpa:
-    open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-    show-sql: false
-    generate-ddl: false
-    hibernate:
-      ddl-auto: none
 
   datasource:
     url: 'jdbc:postgresql://localhost:5432/job-board?sslmode=prefer'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,9 +46,6 @@ spring:
 
   jpa:
     open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: false
     generate-ddl: false
     hibernate:


### PR DESCRIPTION
This PR removes some unnecessary JPA configuration options from the Spring boot application:

- Dialect is not necessary
- The same configuration that is in developer is provided from the root application configuration. It's not necessary to duplicate it.