### PR TITLE
[ESWE-942] Adds UUID validation when an Employer is created

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod.PUT
+import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import org.springframework.http.MediaType.APPLICATION_JSON
@@ -18,6 +19,25 @@ class EmployerControllerShould : ApplicationTestCase() {
       endpoint = "/employers/1a553b0e-9d0b-46b2-bd78-3fa24b7232da",
       body = sainsburysBody,
       expectedStatus = CREATED,
+    )
+  }
+
+  @Test
+  fun `not create an Employer with invalid UUID`() {
+    assertErrorRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/invalid-uuid",
+      body = tescoBody,
+      expectedStatus = BAD_REQUEST,
+      expectedErrorResponse = """
+        {
+          "status":400,
+          "errorCode":null,
+          "userMessage":"Validation failure: createEmployer.id: Invalid UUID format",
+          "developerMessage":"createEmployer.id: Invalid UUID format",
+          "moreInfo":null
+        }
+      """.trimIndent(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -54,7 +55,12 @@ class EmployerController(
     ],
   )
   fun createEmployer(
-    @PathVariable id: String,
+    @PathVariable
+    @Pattern(
+      regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      message = "Invalid UUID format",
+    )
+    id: String,
     @Valid @RequestBody createEmployerRequest: CreateEmployerRequest,
   ): ResponseEntity<String> {
     jobEmployerService.createEmployer(createEmployerRequest.copy(id = id))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/entity/EntityId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/entity/EntityId.kt
@@ -9,15 +9,16 @@ data class EntityId(val id: String) : Serializable {
   constructor() : this(UUID.randomUUID().toString())
 
   init {
-    require(isValidUUID(id)) { "Invalid UUID format: $id" }
+    require(id.isNotEmpty()) { "EntityId cannot be empty" }
+    require(!id.equals("00000000-0000-0000-0000-00000")) { "EntityId cannot be null: {$id}" }
+    require(isValidUUID(id)) { "Invalid UUID format: {$id}" }
   }
 
   override fun toString(): String = id
 
-  private fun isValidUUID(uuidString: String): Boolean {
+  private fun isValidUUID(uuid: String): Boolean {
     return try {
-      UUID.fromString(uuidString)
-      true
+      id == UUID.fromString(uuid).toString()
     } catch (error: IllegalArgumentException) {
       false
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/entity/EntityIdShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/entity/EntityIdShould.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.unit.entity
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class EntityIdShould {
+
+  @Test
+  fun `create EntityId with valid UUID`() {
+    val validUUID = "57cc41f1-6a1e-4793-8921-97b02016b290"
+    val entityId = EntityId(validUUID)
+    assertEquals(validUUID, entityId.id)
+  }
+
+  @Test
+  fun `throw exception for invalid UUID`() {
+    val invalidUUID = "invalid-uuid"
+    val exception = assertFailsWith<IllegalArgumentException> {
+      EntityId(invalidUUID)
+    }
+    assertEquals("Invalid UUID format: {$invalidUUID}", exception.message)
+  }
+
+  @Test
+  fun `throw exception for empty UUID`() {
+    val exception = assertFailsWith<IllegalArgumentException> {
+      EntityId("")
+    }
+    assertEquals("EntityId cannot be empty", exception.message)
+  }
+
+  @Test
+  fun `throw exception for null UUID`() {
+    val invalidUUID = "00000000-0000-0000-0000-00000"
+    val exception = assertFailsWith<IllegalArgumentException> {
+      EntityId(invalidUUID)
+    }
+    assertEquals("EntityId cannot be null: {$invalidUUID}", exception.message)
+  }
+
+  @Test
+  fun `throw exception for incomplete UUID`() {
+    val invalidUUID = "68bba8de-4542-4f4c-9a3d-0"
+    val exception = assertFailsWith<IllegalArgumentException> {
+      EntityId(invalidUUID)
+    }
+    assertEquals("Invalid UUID format: {$invalidUUID}", exception.message)
+    println(exception.message)
+  }
+}


### PR DESCRIPTION
This pull request:
- UUID validation is added at the entity, service, and controller levels.
- Extend acceptance testing functions to test error scenarios
- Some minor test refactor