### PR TITLE
[ESWE-942] Adds a different behaviour for Employer update

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
@@ -33,11 +33,34 @@ class EmployerControllerShould : ApplicationTestCase() {
         {
           "status":400,
           "errorCode":null,
-          "userMessage":"Validation failure: createEmployer.id: Invalid UUID format",
-          "developerMessage":"createEmployer.id: Invalid UUID format",
+          "userMessage":"Validation failure: save.id: Invalid UUID format",
+          "developerMessage":"save.id: Invalid UUID format",
           "moreInfo":null
         }
       """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `update an existing Employer`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = sainsburysBody,
+      expectedStatus = OK,
+    )
+
+    assertResponse(
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      expectedStatus = OK,
+      expectedResponse = sainsburysBody,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
@@ -13,14 +13,18 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.time.TimeProvider
 
 @Service
 class EmployerService(
-  private val jobEmployerRepository: EmployerRepository,
+  private val employerRepository: EmployerRepository,
   private val timeProvider: TimeProvider,
 ) {
 
-  fun createEmployer(
+  fun existsById(employerId: String): Boolean {
+    return employerRepository.existsById(EntityId(employerId))
+  }
+
+  fun save(
     request: CreateEmployerRequest,
   ) {
-    jobEmployerRepository.save(
+    employerRepository.save(
       Employer(
         id = EntityId(request.id),
         name = request.name,
@@ -32,14 +36,14 @@ class EmployerService(
     )
   }
 
-  fun retrieveEmployer(id: String): Employer {
-    return jobEmployerRepository.findById(EntityId(id)).orElseThrow { RuntimeException("Employer not found") }
+  fun retrieve(id: String): Employer {
+    return employerRepository.findById(EntityId(id)).orElseThrow { RuntimeException("Employer not found") }
   }
 
   fun getPagingList(pageNo: Int, pageSize: Int, sortBy: String): MutableList<Employer>? {
     val paging: Pageable = PageRequest.of(pageNo.toInt(), pageSize.toInt(), Sort.by(sortBy))
 
-    val pagedResult: Page<Employer> = jobEmployerRepository.findAll(paging)
+    val pagedResult: Page<Employer> = employerRepository.findAll(paging)
 
     if (pagedResult.hasContent()) {
       return pagedResult.getContent()


### PR DESCRIPTION
This PR:
- Adds a different Employers endpoint behaviour when a resource item is updated. The consumer will receive a 200 OK HTTP status instead of a 201 Created.
- EmployerService exposes a new method to check if an Employer already exists.
- Fixes errors on the acceptance test base assertions
- Refactored some names to remove duplication and make them more expressive