### PR TITLE
[ESWE-964] Adds the ability to return a list of all Employers

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
@@ -1,14 +1,10 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
-import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.get
 
 class EmployerControllerShould : ApplicationTestCase() {
 
@@ -80,47 +76,44 @@ class EmployerControllerShould : ApplicationTestCase() {
     )
   }
 
-  @Disabled
   @Test
-  fun `get all Jobs`() {
-    val httpHeaders: HttpHeaders =
-      this.setAuthorisation(roles = listOf("ROLE_EDUCATION_WORK_PLAN_EDIT"))
+  fun `retrieve an empty list of Employers`() {
+    assertResponse(
+      endpoint = "/employers",
+      expectedStatus = OK,
+      expectedResponse = "[]",
+    )
+  }
 
-    mockMvc.get("/job-board/employer/test/list?pageNo=0&pageSize=10&sortBy=id") {
-      contentType = APPLICATION_JSON
-      accept = APPLICATION_JSON
-      headers {
-        httpHeaders.forEach { (name, values) ->
-          values.forEach { value ->
-            header(name, value)
-          }
-        }
-      }
-    }.andExpect {
-      status { isOk() }
-      content {
-        contentType(APPLICATION_JSON)
-        json(
-          """
-        {
-            "id": "1a553b0e-9d0b-46b2-bd78-3fa24b7232da",
-            "name": "Saynsbury's",
-            "description": "This is the employer BIO",
-            "sector": "sector name",
-            "status": "status"
-        }
-          """.trimIndent(),
-        )
-      }
-    }
+  @Test
+  fun `retrieve all Employers`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers",
+      expectedStatus = OK,
+      expectedResponse = "[ $tescoBody, $sainsburysBody ]",
+    )
   }
 
   val tescoBody: String = """
         {
           "name": "Tesco",
           "description": "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
-          "sector": "sector",
-          "status": "status"
+          "sector": "RETAIL",
+          "status": "SILVER"
         }
   """.trimIndent()
 
@@ -128,8 +121,8 @@ class EmployerControllerShould : ApplicationTestCase() {
         {
           "name": "Sainsbury's",
           "description": "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
-          "sector": "sector",
-          "status": "status"
+          "sector": "RETAIL",
+          "status": "GOLD"
         }
   """.trimIndent()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import uk.gov.justice.digital.hmpps.jobsboard.api.config.ErrorResponse
@@ -119,8 +117,8 @@ class EmployerController(
     return ResponseEntity.ok().body(GetEmployerResponse.from(employer))
   }
 
-  @PreAuthorize("hasRole('WORK_READINESS_EDIT') or hasRole('ROLE_EDUCATION_WORK_PLAN_EDIT')")
-  @GetMapping("/test/list")
+  @PreAuthorize("hasRole('ROLE_EDUCATION_WORK_PLAN_VIEW') or hasRole('ROLE_EDUCATION_WORK_PLAN_EDIT')")
+  @GetMapping("")
   @Operation(
     summary = "Create a job employer ",
     description = "Create a job employer. Currently requires role <b>ROLE_VIEW_PRISONER_DATA</b>",
@@ -147,17 +145,11 @@ class EmployerController(
       ),
     ],
   )
-  fun getEmployerlist(
-    @RequestParam
-    @Parameter(description = "The identifier of the establishment(prison) to get the active bookings for", required = true)
-    pageNo: Int,
-    @RequestParam
-    @Parameter(description = "The identifier of the establishment(prison) to get the active bookings for", required = true)
-    pageSize: Int,
-    @RequestParam
-    @Parameter(description = "The identifier of the establishment(prison) to get the active bookings for", required = true)
-    sortBy: String,
-  ): MutableList<Employer>? {
-    return employerService.getPagingList(pageNo, pageSize, sortBy)
+  fun retrieveAll(): ResponseEntity<List<GetEmployerResponse>>? {
+    val employerList = employerService.getEmployers()
+    val response = employerList.map { it.toResponse() }
+    return ResponseEntity.ok(response)
   }
 }
+
+fun Employer.toResponse() = GetEmployerResponse(id.id, name, description, sector, status, createdAt)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
@@ -1,9 +1,5 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.service
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
@@ -40,15 +36,7 @@ class EmployerService(
     return employerRepository.findById(EntityId(id)).orElseThrow { RuntimeException("Employer not found") }
   }
 
-  fun getPagingList(pageNo: Int, pageSize: Int, sortBy: String): MutableList<Employer>? {
-    val paging: Pageable = PageRequest.of(pageNo.toInt(), pageSize.toInt(), Sort.by(sortBy))
-
-    val pagedResult: Page<Employer> = employerRepository.findAll(paging)
-
-    if (pagedResult.hasContent()) {
-      return pagedResult.getContent()
-    } else {
-      return ArrayList<Employer>()
-    }
+  fun getEmployers(): List<Employer> {
+    return employerRepository.findAll()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/service/EmployerServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/service/EmployerServiceShould.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.unit.service
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -25,8 +26,6 @@ import java.time.Month.JULY
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @ExtendWith(MockitoExtension::class)
 class EmployerServiceShould {
@@ -39,20 +38,31 @@ class EmployerServiceShould {
   private lateinit var employerService: EmployerService
 
   private val fixedTime = LocalDateTime.of(2024, JULY, 20, 22, 6)
-  private val expectedEmployer = Employer(
+  private val tescoEmployer = Employer(
+    id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),
+    name = "Tesco",
+    description = "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
+    sector = "RETAIL",
+    status = "SILVER",
+    createdAt = fixedTime,
+  )
+
+  private val sainsburysEmployer = Employer(
     id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),
     name = "Sainsbury's",
     description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
-    sector = "sector",
-    status = "status",
+    sector = "RETAIL",
+    status = "GOLD",
     createdAt = fixedTime,
   )
+
+  private val expectedEmployer = sainsburysEmployer
   private val createEmployerRequest = CreateEmployerRequest.from(
     id = "eaf7e96e-e45f-461d-bbcb-fd4cedf0499c",
     name = "Sainsbury's",
     description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
-    sector = "sector",
-    status = "status",
+    sector = "RETAIL",
+    status = "GOLD",
   )
 
   @BeforeEach
@@ -61,29 +71,29 @@ class EmployerServiceShould {
   }
 
   @Test
-  fun `create an Employer with valid details`() {
+  fun `save an Employer with valid details`() {
     employerService.save(createEmployerRequest)
 
     val employerCaptor = argumentCaptor<Employer>()
     verify(employerRepository).save(employerCaptor.capture())
     val actualEmployer = employerCaptor.firstValue
 
-    assertEquals(expectedEmployer.id, actualEmployer.id)
-    assertEquals(expectedEmployer.name, actualEmployer.name)
-    assertEquals(expectedEmployer.description, actualEmployer.description)
-    assertEquals(expectedEmployer.sector, actualEmployer.sector)
-    assertEquals(expectedEmployer.status, actualEmployer.status)
+    assertThat(expectedEmployer.id).isEqualTo(actualEmployer.id)
+    assertThat(expectedEmployer.name).isEqualTo(actualEmployer.name)
+    assertThat(expectedEmployer.description).isEqualTo(actualEmployer.description)
+    assertThat(expectedEmployer.sector).isEqualTo(actualEmployer.sector)
+    assertThat(expectedEmployer.status).isEqualTo(actualEmployer.status)
   }
 
   @Test
-  fun `create an Employer with current time`() {
+  fun `save an Employer with current time`() {
     employerService.save(createEmployerRequest)
 
     val employerCaptor = argumentCaptor<Employer>()
     verify(employerRepository).save(employerCaptor.capture())
     val actualEmployer = employerCaptor.firstValue
 
-    assertEquals(expectedEmployer.createdAt, actualEmployer.createdAt)
+    assertThat(expectedEmployer.createdAt).isEqualTo(actualEmployer.createdAt)
   }
 
   @Test
@@ -100,7 +110,7 @@ class EmployerServiceShould {
       employerService.save(createEmployerRequest)
     }
 
-    assertEquals("Invalid UUID format: {${createEmployerRequest.id}}", exception.message)
+    assertThat("Invalid UUID format: {${createEmployerRequest.id}}").isEqualTo(exception.message)
     verify(employerRepository, never()).save(any(Employer::class.java))
   }
 
@@ -118,7 +128,7 @@ class EmployerServiceShould {
       employerService.save(createEmployerRequest)
     }
 
-    assertEquals("EntityId cannot be empty", exception.message)
+    assertThat("EntityId cannot be empty").isEqualTo(exception.message)
     verify(employerRepository, never()).save(any(Employer::class.java))
   }
 
@@ -136,7 +146,7 @@ class EmployerServiceShould {
       employerService.save(createEmployerRequest)
     }
 
-    assertEquals("EntityId cannot be null: {${createEmployerRequest.id}}", exception.message)
+    assertThat("EntityId cannot be null: {${createEmployerRequest.id}}").isEqualTo(exception.message)
     verify(employerRepository, never()).save(any(Employer::class.java))
   }
 
@@ -145,7 +155,7 @@ class EmployerServiceShould {
     val employerId = UUID.randomUUID().toString()
     whenever(employerRepository.existsById(EntityId(employerId))).thenReturn(true)
 
-    assertTrue(employerService.existsById(employerId))
+    assertThat(employerService.existsById(employerId)).isTrue()
   }
 
   @Test
@@ -153,11 +163,11 @@ class EmployerServiceShould {
     val employerId = UUID.randomUUID().toString()
     whenever(employerRepository.existsById(EntityId(employerId))).thenReturn(false)
 
-    assertFalse(employerService.existsById(employerId))
+    assertThat(employerService.existsById(employerId)).isFalse()
   }
 
   @Test
-  fun `retrieve an Employer when found`() {
+  fun `return an Employer when found`() {
     `when`(employerRepository.findById(EntityId("1db79c55-cc88-4a1d-94fa-7a21c590c713"))).thenReturn(
       Optional.of(
         expectedEmployer,
@@ -180,5 +190,16 @@ class EmployerServiceShould {
 
     assertEquals("Employer not found", exception.message)
     verify(employerRepository, times(1)).findById(EntityId("39683af0-eb4c-4fd4-b6a5-34a26d6b9039"))
+  }
+
+  @Test
+  fun `return all employers`() {
+    val employers = listOf(tescoEmployer, sainsburysEmployer)
+    whenever(employerRepository.findAll()).thenReturn(employers)
+
+    val result = employerService.getEmployers()
+
+    assertThat(result).hasSize(2)
+    assertThat(result).isEqualTo(employers)
   }
 }


### PR DESCRIPTION
The purpose of this pull request is to provide a very primitive capability of the `Employers` endpoint to return a list of all items stored in the database:
- Adds the ability to the endpoint to return a simple list of `Employers`
- Does some test refactor to use asserThat over `asserEquals` or `assertTrue`/`assertFalse`

Out of scope:
- Filtering
- Pagination
- Ordering