### PR TITLE
[ESWE-945] Adds name and sector filtering on the Employers endpoint

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
@@ -77,7 +77,7 @@ class EmployerControllerShould : ApplicationTestCase() {
   }
 
   @Test
-  fun `retrieve paginated empty list of all Employers`() {
+  fun `retrieve a paginated empty list of Employers when none registered`() {
     assertResponse(
       endpoint = "/employers",
       expectedStatus = OK,
@@ -96,7 +96,40 @@ class EmployerControllerShould : ApplicationTestCase() {
   }
 
   @Test
-  fun `retrieve the second page of paginated list of all Employers`() {
+  fun `retrieve a default paginated list of all Employers when no filter or pagination applied`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers",
+      expectedStatus = OK,
+      expectedResponse = """
+        {
+          "content": [ $tescoBody, $sainsburysBody ],
+          "page": {
+            "size": 10,
+            "number": 0,
+            "totalElements": 2,
+            "totalPages": 1
+          }
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `retrieve specific page of paginated list of Employers when page and size are informed`() {
     assertRequestWithBody(
       method = PUT,
       endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
@@ -128,6 +161,166 @@ class EmployerControllerShould : ApplicationTestCase() {
     )
   }
 
+  @Test
+  fun `retrieve a default paginated list of Employers filtered by name when filtered is applied`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers?name=Tesco",
+      expectedStatus = OK,
+      expectedResponse = """
+          {
+            "content": [ $tescoBody ],
+            "page": {
+              "size": 10,
+              "number": 0,
+              "totalElements": 1,
+              "totalPages": 1
+            }
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `retrieve a default paginated list of Employers filtered by sector when filtered is applied`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = amazonBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers?sector=LOGISTICS",
+      expectedStatus = OK,
+      expectedResponse = """
+          {
+            "content": [ $amazonBody ],
+            "page": {
+              "size": 10,
+              "number": 0,
+              "totalElements": 1,
+              "totalPages": 1
+            }
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `retrieve a default paginated list of Employers filtered by name AND sector when filters are applied`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/2aff5cfe-ffdd-4a52-b672-26638e7be060",
+      body = tescoLogisticsBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0f9d76ab-55e9-411c-8def-24eeb734c83f",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = amazonBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers?name=Tesco&sector=LOGISTICS",
+      expectedStatus = OK,
+      expectedResponse = """
+          {
+            "content": [ $tescoLogisticsBody ],
+            "page": {
+              "size": 10,
+              "number": 0,
+              "totalElements": 1,
+              "totalPages": 1
+            }
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `retrieve second page of Employers list filtered by name AND sector when filters and custom pagination are applied`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/2aff5cfe-ffdd-4a52-b672-26638e7be060",
+      body = tescoLogisticsBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0f9d76ab-55e9-411c-8def-24eeb734c83f",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = amazonBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers?name=Sainsbury's&sector=RETAIL&page=0&size=1",
+      expectedStatus = OK,
+      expectedResponse = """
+          {
+            "content": [ $sainsburysBody ],
+            "page": {
+              "size": 1,
+              "number":0,
+              "totalElements": 1,
+              "totalPages": 1
+            }
+        }
+      """.trimIndent(),
+    )
+  }
+
   val tescoBody: String = """
         {
           "name": "Tesco",
@@ -137,12 +330,30 @@ class EmployerControllerShould : ApplicationTestCase() {
         }
   """.trimIndent()
 
+  val tescoLogisticsBody: String = """
+        {
+          "name": "Tesco",
+          "description": "This is another Tesco employer that provides logistic services.",
+          "sector": "LOGISTICS",
+          "status": "GOLD"
+        }
+  """.trimIndent()
+
   val sainsburysBody = """
         {
           "name": "Sainsbury's",
           "description": "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
           "sector": "RETAIL",
           "status": "GOLD"
+        }
+  """.trimIndent()
+
+  val amazonBody = """
+        {
+          "name": "Amazon",
+          "description": "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence",
+          "sector": "LOGISTICS",
+          "status": "KEY_PARTNER"
         }
   """.trimIndent()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Pattern
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -148,12 +149,17 @@ class EmployerController(
     ],
   )
   fun retrieveAll(
+    @RequestParam(required = false)
+    name: String?,
+    @RequestParam(required = false)
+    sector: String?,
     @RequestParam(defaultValue = "0")
     page: Int,
     @RequestParam(defaultValue = "10")
     size: Int,
   ): ResponseEntity<Page<GetEmployerResponse>>? {
-    val employerList = employerService.getAllEmployers(page, size)
+    val pageable: Pageable = Pageable.ofSize(size).withPage(page)
+    val employerList = employerService.getAllEmployers(name, sector, pageable)
     val response = employerList.map { it.toResponse() }
     return ResponseEntity.ok(response)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/repository/EmployerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/repository/EmployerRepository.kt
@@ -1,9 +1,15 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 @Repository
-interface EmployerRepository : JpaRepository<Employer, EntityId>
+interface EmployerRepository : JpaRepository<Employer, EntityId> {
+  fun findByName(name: String?, pageable: Pageable): Page<Employer>
+  fun findBySector(sector: String?, pageable: Pageable): Page<Employer>
+  fun findByNameAndSector(name: String?, sector: String?, pageable: Pageable): Page<Employer>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.service
 
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
@@ -38,9 +38,12 @@ class EmployerService(
     return employerRepository.findById(EntityId(id)).orElseThrow { RuntimeException("Employer not found") }
   }
 
-  fun getAllEmployers(page: Int, size: Int): Page<Employer> {
-    val pageable = PageRequest.of(page, size)
-    val employers = employerRepository.findAll(pageable)
-    return employers.map { it }
+  fun getAllEmployers(name: String?, sector: String?, pageable: Pageable): Page<Employer> {
+    return when {
+      !name.isNullOrEmpty() && sector.isNullOrEmpty() -> employerRepository.findByName(name, pageable)
+      name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findBySector(sector, pageable)
+      !name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findByNameAndSector(name, sector, pageable)
+      else -> employerRepository.findAll(pageable)
+    }
   }
 }


### PR DESCRIPTION
This PR:
- Adds name and sector filtering
- Uses the Springframework `Pageable` static factory to produce `pageRequest` objects
- Small refactors on service tests.