### PR TITLE
[ESWE-945] Name and sector Employers filtering ignores text case

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
@@ -178,7 +178,7 @@ class EmployerControllerShould : ApplicationTestCase() {
     )
 
     assertResponse(
-      endpoint = "/employers?name=Tesco",
+      endpoint = "/employers?name=tesco",
       expectedStatus = OK,
       expectedResponse = """
           {
@@ -211,7 +211,7 @@ class EmployerControllerShould : ApplicationTestCase() {
     )
 
     assertResponse(
-      endpoint = "/employers?sector=LOGISTICS",
+      endpoint = "/employers?sector=logistics",
       expectedStatus = OK,
       expectedResponse = """
           {
@@ -263,6 +263,53 @@ class EmployerControllerShould : ApplicationTestCase() {
       expectedResponse = """
           {
             "content": [ $tescoLogisticsBody ],
+            "page": {
+              "size": 10,
+              "number": 0,
+              "totalElements": 1,
+              "totalPages": 1
+            }
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `retrieve a list of Employers filtered by name AND sector when filters are applied with mixed cases`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/2aff5cfe-ffdd-4a52-b672-26638e7be060",
+      body = tescoLogisticsBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0f9d76ab-55e9-411c-8def-24eeb734c83f",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = amazonBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers?name=sAINSBURY'S&sector=retail",
+      expectedStatus = OK,
+      expectedResponse = """
+          {
+            "content": [ $sainsburysBody ],
             "page": {
               "size": 10,
               "number": 0,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/repository/EmployerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/repository/EmployerRepository.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 @Repository
 interface EmployerRepository : JpaRepository<Employer, EntityId> {
-  fun findByName(name: String?, pageable: Pageable): Page<Employer>
-  fun findBySector(sector: String?, pageable: Pageable): Page<Employer>
-  fun findByNameAndSector(name: String?, sector: String?, pageable: Pageable): Page<Employer>
+  fun findByNameIgnoringCase(name: String?, pageable: Pageable): Page<Employer>
+  fun findBySectorIgnoringCase(sector: String?, pageable: Pageable): Page<Employer>
+  fun findByNameAndSectorAllIgnoringCase(name: String?, sector: String?, pageable: Pageable): Page<Employer>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
@@ -40,9 +40,9 @@ class EmployerService(
 
   fun getAllEmployers(name: String?, sector: String?, pageable: Pageable): Page<Employer> {
     return when {
-      !name.isNullOrEmpty() && sector.isNullOrEmpty() -> employerRepository.findByName(name, pageable)
-      name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findBySector(sector, pageable)
-      !name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findByNameAndSector(name, sector, pageable)
+      !name.isNullOrEmpty() && sector.isNullOrEmpty() -> employerRepository.findByNameIgnoringCase(name, pageable)
+      name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findBySectorIgnoringCase(sector, pageable)
+      !name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findByNameAndSectorAllIgnoringCase(name, sector, pageable)
       else -> employerRepository.findAll(pageable)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/service/EmployerServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/service/EmployerServiceShould.kt
@@ -221,11 +221,11 @@ class EmployerServiceShould {
     val pageSize = 10
     val pageable = Pageable.ofSize(pageSize).withPage(pageNumber)
     val pagedResult: Page<Employer> = PageImpl(employers, pageable, employers.size.toLong())
-    whenever(employerRepository.findByName(name, pageable)).thenReturn(pagedResult)
+    whenever(employerRepository.findByNameIgnoringCase(name, pageable)).thenReturn(pagedResult)
 
     val result = employerService.getAllEmployers(name, sector, pageable)
 
-    verify(employerRepository, times(1)).findByName(name, pageable)
+    verify(employerRepository, times(1)).findByNameIgnoringCase(name, pageable)
     assertThat(result.content).isEqualTo(pagedResult.content)
   }
 
@@ -238,11 +238,11 @@ class EmployerServiceShould {
     val pageSize = 10
     val pageable = Pageable.ofSize(pageSize).withPage(pageNumber)
     val pagedResult: Page<Employer> = PageImpl(employers, pageable, employers.size.toLong())
-    whenever(employerRepository.findBySector(sector, pageable)).thenReturn(pagedResult)
+    whenever(employerRepository.findBySectorIgnoringCase(sector, pageable)).thenReturn(pagedResult)
 
     val result = employerService.getAllEmployers(name, sector, pageable)
 
-    verify(employerRepository, times(1)).findBySector(sector, pageable)
+    verify(employerRepository, times(1)).findBySectorIgnoringCase(sector, pageable)
     assertThat(result.content).isEqualTo(pagedResult.content)
   }
 
@@ -255,11 +255,11 @@ class EmployerServiceShould {
     val pageSize = 10
     val pageable = Pageable.ofSize(pageSize).withPage(pageNumber)
     val pagedResult: Page<Employer> = PageImpl(employers, pageable, employers.size.toLong())
-    whenever(employerRepository.findByNameAndSector(name, sector, pageable)).thenReturn(pagedResult)
+    whenever(employerRepository.findByNameAndSectorAllIgnoringCase(name, sector, pageable)).thenReturn(pagedResult)
 
     val result = employerService.getAllEmployers(name, sector, pageable)
 
-    verify(employerRepository, times(1)).findByNameAndSector(name, sector, pageable)
+    verify(employerRepository, times(1)).findByNameAndSectorAllIgnoringCase(name, sector, pageable)
     assertThat(result.content).isEqualTo(pagedResult.content)
   }
 }


### PR DESCRIPTION
This PR modifies the repository method names so the name and sector filters are applied, ignoring the text case. The testing is done from the acceptance testing point of view. Some of the existing acceptance tests are also modified to test this behaviour implicitly.