### PR TITLE
[ESWE-945] Updates Employers filter to allow search with incomplete names

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
@@ -195,6 +195,39 @@ class EmployerControllerShould : ApplicationTestCase() {
   }
 
   @Test
+  fun `retrieve a default paginated list of Employers filtered by incomplete name when filtered is applied`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertResponse(
+      endpoint = "/employers?name=tes",
+      expectedStatus = OK,
+      expectedResponse = """
+          {
+            "content": [ $tescoBody ],
+            "page": {
+              "size": 10,
+              "number": 0,
+              "totalElements": 1,
+              "totalPages": 1
+            }
+        }
+      """.trimIndent(),
+    )
+  }
+
+  @Test
   fun `retrieve a default paginated list of Employers filtered by sector when filtered is applied`() {
     assertRequestWithBody(
       method = PUT,
@@ -275,7 +308,7 @@ class EmployerControllerShould : ApplicationTestCase() {
   }
 
   @Test
-  fun `retrieve a list of Employers filtered by name AND sector when filters are applied with mixed cases`() {
+  fun `retrieve a list of Employers filtered by incomplete name AND sector when filters are applied with mixed cases`() {
     assertRequestWithBody(
       method = PUT,
       endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
@@ -305,7 +338,7 @@ class EmployerControllerShould : ApplicationTestCase() {
     )
 
     assertResponse(
-      endpoint = "/employers?name=sAINSBURY'S&sector=retail",
+      endpoint = "/employers?name=sAINS&sector=retail",
       expectedStatus = OK,
       expectedResponse = """
           {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/repository/EmployerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/repository/EmployerRepository.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 @Repository
 interface EmployerRepository : JpaRepository<Employer, EntityId> {
-  fun findByNameIgnoringCase(name: String?, pageable: Pageable): Page<Employer>
+  fun findByNameIgnoringCaseContaining(name: String?, pageable: Pageable): Page<Employer>
   fun findBySectorIgnoringCase(sector: String?, pageable: Pageable): Page<Employer>
-  fun findByNameAndSectorAllIgnoringCase(name: String?, sector: String?, pageable: Pageable): Page<Employer>
+  fun findByNameContainingAndSectorAllIgnoringCase(name: String?, sector: String?, pageable: Pageable): Page<Employer>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/service/EmployerService.kt
@@ -40,9 +40,9 @@ class EmployerService(
 
   fun getAllEmployers(name: String?, sector: String?, pageable: Pageable): Page<Employer> {
     return when {
-      !name.isNullOrEmpty() && sector.isNullOrEmpty() -> employerRepository.findByNameIgnoringCase(name, pageable)
+      !name.isNullOrEmpty() && sector.isNullOrEmpty() -> employerRepository.findByNameIgnoringCaseContaining(name, pageable)
       name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findBySectorIgnoringCase(sector, pageable)
-      !name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findByNameAndSectorAllIgnoringCase(name, sector, pageable)
+      !name.isNullOrEmpty() && !sector.isNullOrEmpty() -> employerRepository.findByNameContainingAndSectorAllIgnoringCase(name, sector, pageable)
       else -> employerRepository.findAll(pageable)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/service/EmployerServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/unit/service/EmployerServiceShould.kt
@@ -221,11 +221,11 @@ class EmployerServiceShould {
     val pageSize = 10
     val pageable = Pageable.ofSize(pageSize).withPage(pageNumber)
     val pagedResult: Page<Employer> = PageImpl(employers, pageable, employers.size.toLong())
-    whenever(employerRepository.findByNameIgnoringCase(name, pageable)).thenReturn(pagedResult)
+    whenever(employerRepository.findByNameIgnoringCaseContaining(name, pageable)).thenReturn(pagedResult)
 
     val result = employerService.getAllEmployers(name, sector, pageable)
 
-    verify(employerRepository, times(1)).findByNameIgnoringCase(name, pageable)
+    verify(employerRepository, times(1)).findByNameIgnoringCaseContaining(name, pageable)
     assertThat(result.content).isEqualTo(pagedResult.content)
   }
 
@@ -255,11 +255,11 @@ class EmployerServiceShould {
     val pageSize = 10
     val pageable = Pageable.ofSize(pageSize).withPage(pageNumber)
     val pagedResult: Page<Employer> = PageImpl(employers, pageable, employers.size.toLong())
-    whenever(employerRepository.findByNameAndSectorAllIgnoringCase(name, sector, pageable)).thenReturn(pagedResult)
+    whenever(employerRepository.findByNameContainingAndSectorAllIgnoringCase(name, sector, pageable)).thenReturn(pagedResult)
 
     val result = employerService.getAllEmployers(name, sector, pageable)
 
-    verify(employerRepository, times(1)).findByNameAndSectorAllIgnoringCase(name, sector, pageable)
+    verify(employerRepository, times(1)).findByNameContainingAndSectorAllIgnoringCase(name, sector, pageable)
     assertThat(result.content).isEqualTo(pagedResult.content)
   }
 }


### PR DESCRIPTION
This PR updated the Employer's search to allow incomplete name filters. Each employer whose name contains the string passed as a filter will be returned.