### PR TITLE
[ESWE-947] Adds sorting to the list of Employers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ testing {
         testType.set(TestSuiteType.INTEGRATION_TEST)
         kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
         implementation("org.springframework.boot:spring-boot-starter-test")
+        implementation("org.mockito.kotlin:mockito-kotlin:5.3.1")
         implementation("io.jsonwebtoken:jjwt-impl:0.12.5")
         implementation("io.jsonwebtoken:jjwt-jackson:0.12.5")
         runtimeOnly("org.flywaydb:flyway-database-postgresql")

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api
 
 import org.awaitility.Awaitility
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -13,6 +17,7 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request
@@ -22,9 +27,11 @@ import org.springframework.test.web.servlet.result.isEqualTo
 import uk.gov.justice.digital.hmpps.jobsboard.api.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.jobsboard.api.repository.EmployerRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
+import uk.gov.justice.digital.hmpps.jobsboard.api.time.DefaultTimeProvider
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
 
+@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   webEnvironment = RANDOM_PORT,
   classes = [HmppsJobsBoardApi::class, TestConfig::class],
@@ -36,11 +43,14 @@ abstract class ApplicationTestCase {
   @Autowired
   private lateinit var employerRepository: EmployerRepository
 
-  @Autowired
-  lateinit var mockMvc: MockMvc
+  @MockBean
+  protected lateinit var timeProvider: DefaultTimeProvider
 
   @Autowired
-  lateinit var jwtAuthHelper: JwtAuthHelper
+  private lateinit var mockMvc: MockMvc
+
+  @Autowired
+  private lateinit var jwtAuthHelper: JwtAuthHelper
 
   companion object {
     private val postgresContainer = PostgresContainer.instance
@@ -65,8 +75,9 @@ abstract class ApplicationTestCase {
   }
 
   @BeforeEach
-  fun clearDatabase() {
+  fun setup() {
     employerRepository.deleteAll()
+    whenever(timeProvider.now()).thenCallRealMethod()
   }
 
   internal fun setAuthorisation(
@@ -114,6 +125,60 @@ abstract class ApplicationTestCase {
       content {
         contentType(APPLICATION_JSON)
         json(expectedResponse)
+      }
+    }
+  }
+
+  @Throws(Exception::class)
+  fun assertSortedByNameResponse(
+    endpoint: String,
+    expectedStatus: HttpStatus,
+    expectedOrderedContentNames: List<String>,
+  ) {
+    val httpHeaders: HttpHeaders = this.setAuthorisation(roles = listOf("ROLE_EDUCATION_WORK_PLAN_VIEW"))
+    mockMvc.get(endpoint) {
+      contentType = APPLICATION_JSON
+      accept = APPLICATION_JSON
+      headers {
+        httpHeaders.forEach { (name, values) ->
+          values.forEach { value ->
+            header(name, value)
+          }
+        }
+      }
+    }.andExpect {
+      status { isEqualTo(expectedStatus.value()) }
+      content {
+        contentType(APPLICATION_JSON)
+        jsonPath("$.content[0].name", equalTo(expectedOrderedContentNames[0]))
+        jsonPath("$.content[1].name", equalTo(expectedOrderedContentNames[1]))
+      }
+    }
+  }
+
+  @Throws(Exception::class)
+  fun assertSortedByDateResponse(
+    endpoint: String,
+    expectedStatus: HttpStatus,
+    expectedOrderedContentDates: List<String>,
+  ) {
+    val httpHeaders: HttpHeaders = this.setAuthorisation(roles = listOf("ROLE_EDUCATION_WORK_PLAN_VIEW"))
+    mockMvc.get(endpoint) {
+      contentType = APPLICATION_JSON
+      accept = APPLICATION_JSON
+      headers {
+        httpHeaders.forEach { (name, values) ->
+          values.forEach { value ->
+            header(name, value)
+          }
+        }
+      }
+    }.andExpect {
+      status { isEqualTo(expectedStatus.value()) }
+      content {
+        contentType(APPLICATION_JSON)
+        jsonPath("$.content[0].createdAt", equalTo(expectedOrderedContentDates[0]))
+        jsonPath("$.content[1].createdAt", equalTo(expectedOrderedContentDates[1]))
       }
     }
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerControllerShould.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
 import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
+import java.time.LocalDateTime
 
 class EmployerControllerShould : ApplicationTestCase() {
 
@@ -96,7 +98,7 @@ class EmployerControllerShould : ApplicationTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated list of all Employers when no filter or pagination applied`() {
+  fun `retrieve a default paginated Employers list`() {
     assertRequestWithBody(
       method = PUT,
       endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
@@ -129,7 +131,7 @@ class EmployerControllerShould : ApplicationTestCase() {
   }
 
   @Test
-  fun `retrieve specific page of paginated list of Employers when page and size are informed`() {
+  fun `retrieve second page of paginated list of Employers when page and size are informed`() {
     assertRequestWithBody(
       method = PUT,
       endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
@@ -149,7 +151,7 @@ class EmployerControllerShould : ApplicationTestCase() {
       expectedStatus = OK,
       expectedResponse = """
           {
-            "content": [ $sainsburysBody ],
+            "content": [ $tescoBody ],
             "page": {
               "size": 1,
               "number": 1,
@@ -398,6 +400,108 @@ class EmployerControllerShould : ApplicationTestCase() {
             }
         }
       """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `retrieve a default sorted by name in ascendent order Employers list`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertSortedByNameResponse(
+      endpoint = "/employers",
+      expectedStatus = OK,
+      expectedOrderedContentNames = listOf("Sainsbury's", "Tesco"),
+    )
+  }
+
+  @Test
+  fun `retrieve an Employers list sorted by name in descendent order when sorting applied`() {
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertSortedByNameResponse(
+      endpoint = "/employers?sortBy=name&sortOrder=desc",
+      expectedStatus = OK,
+      expectedOrderedContentNames = listOf("Tesco", "Sainsbury's"),
+    )
+  }
+
+  @Test
+  fun `retrieve an Employers list sorted by date added in default ascendent order when sort-by applied`() {
+    val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
+    whenever(timeProvider.now())
+      .thenReturn(fixedTime)
+      .thenReturn(fixedTime.plusDays(1))
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertSortedByDateResponse(
+      endpoint = "/employers?sortBy=createdAt",
+      expectedStatus = OK,
+      expectedOrderedContentDates = listOf("2024-07-01T01:00:00", "2024-07-02T01:00:00"),
+    )
+  }
+
+  @Test
+  fun `retrieve an Employers list sorted by date added in descendent order when sort-by and sort-order applied`() {
+    val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
+    whenever(timeProvider.now())
+      .thenReturn(fixedTime)
+      .thenReturn(fixedTime.plusDays(1))
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/0fec6332-0839-4a4a-9c15-b86c06e1ca03",
+      body = tescoBody,
+      expectedStatus = CREATED,
+    )
+
+    assertRequestWithBody(
+      method = PUT,
+      endpoint = "/employers/e82fd9e6-ffcf-410c-a7c8-ffeb50da3f18",
+      body = sainsburysBody,
+      expectedStatus = CREATED,
+    )
+
+    assertSortedByDateResponse(
+      endpoint = "/employers?sortBy=createdAt&sortOrder=desc",
+      expectedStatus = OK,
+      expectedOrderedContentDates = listOf("2024-07-02T01:00:00", "2024-07-01T01:00:00"),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/EmployerController.kt
@@ -7,7 +7,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Pattern
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -153,12 +155,17 @@ class EmployerController(
     name: String?,
     @RequestParam(required = false)
     sector: String?,
+    @RequestParam(defaultValue = "name", required = false)
+    sortBy: String?,
+    @RequestParam(defaultValue = "asc", required = false)
+    sortOrder: String?,
     @RequestParam(defaultValue = "0")
     page: Int,
     @RequestParam(defaultValue = "10")
     size: Int,
   ): ResponseEntity<Page<GetEmployerResponse>>? {
-    val pageable: Pageable = Pageable.ofSize(size).withPage(page)
+    val direction = if (sortOrder.equals("desc", ignoreCase = true)) Sort.Direction.DESC else Sort.Direction.ASC
+    val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortBy))
     val employerList = employerService.getAllEmployers(name, sector, pageable)
     val response = employerList.map { it.toResponse() }
     return ResponseEntity.ok(response)


### PR DESCRIPTION
This PR adds sorting to the list of Employers:
- By default, the list of Employers is sorted by name
- By default, the order is ascendent.
- The order can be descendent using `sortOrder=desc`
- The sorted field can be changed to date added using `sortby=createdAt`
- The sort and order fields can be used with pagination and filters.