### PR TITLE
[ESWE-960] Get job contains createdAt attribute

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.auditing.DateTimeProvider
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus
@@ -63,6 +64,9 @@ abstract class ApplicationTestCase {
 
   @MockBean
   protected lateinit var timeProvider: DefaultTimeProvider
+
+  @MockBean
+  protected lateinit var dateTimeProvider: DateTimeProvider
 
   @Autowired
   protected lateinit var mockMvc: MockMvc

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/TestJpaConfig.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/TestJpaConfig.kt
@@ -3,14 +3,16 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.config
 import org.mockito.Mockito.mock
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.data.auditing.DateTimeProvider
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @TestConfiguration
-@Profile("test-containers")
 @EnableJpaAuditing(dateTimeProviderRef = "dateTimeProvider")
+@Profile("test-containers")
 class TestJpaConfig {
+  @Primary
   @Bean
   fun dateTimeProvider(): DateTimeProvider {
     return mock(DateTimeProvider::class.java)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -1,12 +1,11 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus.CREATED
-import java.time.Instant
 import java.util.*
 
 class JobsGetShould : JobsTestCase() {
+
   @Test
   fun `retrieve an existing Job`() {
     assertAddEmployer(
@@ -19,7 +18,7 @@ class JobsGetShould : JobsTestCase() {
 
     assertGetJobIsOK(
       jobId = jobId,
-      expectedResponse = amazonForkliftOperatorJobBody,
+      expectedResponse = amazonForkliftOperatorJobResponse(jobCreationTime),
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -1,7 +1,10 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus.CREATED
+import java.time.Instant
+import java.util.*
 
 class JobsGetShould : JobsTestCase() {
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -96,7 +96,6 @@ class JobsTestCase : ApplicationTestCase() {
     isOnlyForPrisonLeavers = true,
     supportingDocumentationRequired = listOf("DISCLOSURE_LETTER", "OTHER"),
     supportingDocumentationDetails = "Some text",
-    createdAt = Instant.now().toString()
   )
 
   protected val tescoWarehouseHandlerJobBody: String = newJobBody(
@@ -129,7 +128,6 @@ class JobsTestCase : ApplicationTestCase() {
     isOnlyForPrisonLeavers = true,
     supportingDocumentationRequired = listOf("DISCLOSURE_LETTER", "OTHER"),
     supportingDocumentationDetails = null,
-    createdAt = Instant.now().toString()
   )
 
   protected val amazonForkliftOperatorJobBody: String = newJobBody(
@@ -179,10 +177,59 @@ class JobsTestCase : ApplicationTestCase() {
     howToApply = "",
     supportingDocumentationRequired = listOf("CV", "DISCLOSURE_LETTER"),
     supportingDocumentationDetails = "",
-    createdAt = Instant.now().toString()
   )
 
-  private fun newJobBody(
+  protected fun amazonForkliftOperatorJobResponse(createdAt: Instant): String = newJobResponse(
+    employerId = "bf392249-b360-4e3e-81a0-8497047987e8",
+    jobTitle = "Forklift operator",
+    sector = "WAREHOUSING",
+    industrySector = "LOGISTICS",
+    numberOfVacancies = 2,
+    sourcePrimary = "PEL",
+    sourceSecondary = "",
+    charityName = "",
+    postCode = "LS12",
+    salaryFrom = 11.93f,
+    salaryTo = 15.90f,
+    salaryPeriod = "PER_HOUR",
+    additionalSalaryInformation = "",
+    isPayingAtLeastNationalMinimumWage = false,
+    workPattern = "FLEXIBLE_SHIFTS",
+    hoursPerWeek = "FULL_TIME",
+    contractType = "TEMPORARY",
+    baseLocation = "WORKPLACE",
+    essentialCriteria = "",
+    desirableCriteria = "",
+    description = """
+      What's on offer:
+
+      - 5 days over 7, 05:30 to 15:30
+      - Paid weekly
+      - Immediate starts available
+      - Full training provided
+      
+      Your duties will include:
+
+      - Manoeuvring forklifts safely in busy industrial environments
+      - Safely stacking and unstacking large quantities of goods onto shelves or pallets
+      - Moving goods from storage areas to loading areas for transport
+      - Unloading deliveries and safely relocating the goods to their designated storage areas
+      - Ensuring forklift driving areas are free from spills or obstructions
+      - Regularly checking forklift equipment for faults or damages
+      - Consolidating partial pallets for incoming goods
+    """.trimIndent(),
+    offenceExclusions = listOf("NONE", "DRIVING"),
+    isRollingOpportunity = false,
+    closingDate = "2025-02-01",
+    isOnlyForPrisonLeavers = true,
+    startDate = "2025-05-31",
+    howToApply = "",
+    supportingDocumentationRequired = listOf("CV", "DISCLOSURE_LETTER"),
+    supportingDocumentationDetails = "",
+    createdAt = createdAt.toString(),
+  )
+
+  private fun newJobResponse(
     employerId: String,
     jobTitle: String,
     sector: String,
@@ -246,6 +293,72 @@ class JobsTestCase : ApplicationTestCase() {
           "supportingDocumentationRequired": ${supportingDocumentationRequired.asJson()},
           "supportingDocumentationDetails": ${supportingDocumentationDetails?.asJson()},
           "createdAt": "$createdAt"
+        }
+    """.trimIndent()
+  }
+
+  private fun newJobBody(
+    employerId: String,
+    jobTitle: String,
+    sector: String,
+    industrySector: String,
+    numberOfVacancies: Int,
+    sourcePrimary: String,
+    sourceSecondary: String? = null,
+    charityName: String? = null,
+    postCode: String,
+    salaryFrom: Float,
+    salaryTo: Float? = null,
+    salaryPeriod: String,
+    additionalSalaryInformation: String? = null,
+    isPayingAtLeastNationalMinimumWage: Boolean,
+    workPattern: String,
+    hoursPerWeek: String,
+    contractType: String,
+    baseLocation: String,
+    essentialCriteria: String,
+    desirableCriteria: String? = null,
+    description: String,
+    offenceExclusions: List<String>,
+    isRollingOpportunity: Boolean,
+    closingDate: String? = null,
+    isOnlyForPrisonLeavers: Boolean,
+    startDate: String? = null,
+    howToApply: String,
+    supportingDocumentationRequired: List<String>,
+    supportingDocumentationDetails: String? = null,
+  ): String {
+    return """
+        {
+          "employerId": "$employerId",
+          "jobTitle": "$jobTitle",
+          "sector": "$sector",
+          "industrySector": "$industrySector",
+          "numberOfVacancies": $numberOfVacancies,
+          "sourcePrimary": "$sourcePrimary",
+          "sourceSecondary": ${sourceSecondary?.asJson()},
+          "charityName": ${charityName?.asJson()},
+          "postCode": "$postCode",
+          "salaryFrom": $salaryFrom,
+          "salaryTo": $salaryTo,
+          "salaryPeriod": "$salaryPeriod",
+          "additionalSalaryInformation": ${additionalSalaryInformation?.asJson()},
+          "isPayingAtLeastNationalMinimumWage": $isPayingAtLeastNationalMinimumWage,
+          "workPattern": "$workPattern",
+          "hoursPerWeek": "$hoursPerWeek",
+          "contractType": "$contractType",
+          "baseLocation": "$baseLocation",
+          "essentialCriteria": "$essentialCriteria",
+          "desirableCriteria": ${desirableCriteria?.asJson()},
+          "description": ${description.asJson()},
+          "offenceExclusions": ${offenceExclusions.asJson()},
+          "isRollingOpportunity": $isRollingOpportunity,
+          "closingDate": ${closingDate?.asJson()},
+          "isOnlyForPrisonLeavers": $isOnlyForPrisonLeavers,
+          "startDate": ${startDate?.asJson()},
+          "howToApply": "$howToApply",
+          "supportingDocumentationRequired": ${supportingDocumentationRequired.asJson()},
+          "supportingDocumentationDetails": ${supportingDocumentationDetails?.asJson()}
         }
     """.trimIndent()
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
+import java.time.Instant
 import java.util.UUID.randomUUID
 
 const val JOBS_ENDPOINT = "/jobs"
@@ -95,6 +96,7 @@ class JobsTestCase : ApplicationTestCase() {
     isOnlyForPrisonLeavers = true,
     supportingDocumentationRequired = listOf("DISCLOSURE_LETTER", "OTHER"),
     supportingDocumentationDetails = "Some text",
+    createdAt = Instant.now().toString()
   )
 
   protected val tescoWarehouseHandlerJobBody: String = newJobBody(
@@ -127,6 +129,7 @@ class JobsTestCase : ApplicationTestCase() {
     isOnlyForPrisonLeavers = true,
     supportingDocumentationRequired = listOf("DISCLOSURE_LETTER", "OTHER"),
     supportingDocumentationDetails = null,
+    createdAt = Instant.now().toString()
   )
 
   protected val amazonForkliftOperatorJobBody: String = newJobBody(
@@ -176,6 +179,7 @@ class JobsTestCase : ApplicationTestCase() {
     howToApply = "",
     supportingDocumentationRequired = listOf("CV", "DISCLOSURE_LETTER"),
     supportingDocumentationDetails = "",
+    createdAt = Instant.now().toString()
   )
 
   private fun newJobBody(
@@ -208,6 +212,7 @@ class JobsTestCase : ApplicationTestCase() {
     howToApply: String,
     supportingDocumentationRequired: List<String>,
     supportingDocumentationDetails: String? = null,
+    createdAt: String,
   ): String {
     return """
         {
@@ -239,7 +244,8 @@ class JobsTestCase : ApplicationTestCase() {
           "startDate": ${startDate?.asJson()},
           "howToApply": "$howToApply",
           "supportingDocumentationRequired": ${supportingDocumentationRequired.asJson()},
-          "supportingDocumentationDetails": ${supportingDocumentationDetails?.asJson()}
+          "supportingDocumentationDetails": ${supportingDocumentationDetails?.asJson()},
+          "createdAt": "$createdAt"
         }
     """.trimIndent()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetJobResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetJobResponse.kt
@@ -68,7 +68,7 @@ data class GetJobResponse(
         howToApply = job.howToApply,
         supportingDocumentationRequired = job.supportingDocumentationRequired.asList(),
         supportingDocumentationDetails = job.supportingDocumentationDetails,
-        createdAt = job.createdAt.toString()
+        createdAt = job.createdAt.toString(),
       )
     }
     private fun String.asList(): List<String> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetJobResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetJobResponse.kt
@@ -33,6 +33,7 @@ data class GetJobResponse(
   val howToApply: String,
   val supportingDocumentationRequired: List<String>,
   val supportingDocumentationDetails: String? = null,
+  val createdAt: String,
 ) {
   companion object {
     fun from(job: Job): GetJobResponse {
@@ -67,6 +68,7 @@ data class GetJobResponse(
         howToApply = job.howToApply,
         supportingDocumentationRequired = job.supportingDocumentationRequired.asList(),
         supportingDocumentationDetails = job.supportingDocumentationDetails,
+        createdAt = job.createdAt.toString()
       )
     }
     private fun String.asList(): List<String> {


### PR DESCRIPTION
This PR adds the audit attribute `createdAt` when a Job is retrieved.

It also adds more technical debt that must be addressed in the following deliveries. That debt has increased in how the code manages the fake data as requests, responses, objects and time.

A proper refactor and use of proper creational patterns, like factories or Object Mother, will reduce duplication and make our tests simpler.