### PR TITLE
[Eswe-964] Get empty paginated job list

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -236,4 +236,28 @@ abstract class ApplicationTestCase {
       }
     }
   }
+
+  protected fun expectedResponseListOf(vararg elements: String): String {
+    return expectedResponseListOf(10, 0, elements = elements)
+  }
+
+  protected fun expectedResponseListOf(size: Int, page: Int, vararg elements: String): String {
+    return expectedResponseListOf(size, page, elements.size, *elements)
+  }
+
+  protected fun expectedResponseListOf(size: Int, page: Int, totalElements: Int, vararg elements: String): String {
+    val totalPages = (totalElements + size - 1) / size
+    val expectedResponse = """
+         {
+          "content": [ ${elements.joinToString(separator = ",")}],
+          "page": {
+            "size": $size,
+            "number": $page,
+            "totalElements": $totalElements,
+            "totalPages": $totalPages
+          }
+        }
+    """.trimIndent()
+    return expectedResponse
+  }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
@@ -66,28 +66,4 @@ class EmployerTestCase : ApplicationTestCase() {
       expectedDateSortedList = expectedDatesSorted,
     )
   }
-
-  protected fun expectedResponseListOf(vararg elements: String): String {
-    return expectedResponseListOf(10, 0, elements = elements)
-  }
-
-  protected fun expectedResponseListOf(size: Int, page: Int, vararg elements: String): String {
-    return expectedResponseListOf(size, page, elements.size, *elements)
-  }
-
-  protected fun expectedResponseListOf(size: Int, page: Int, totalElements: Int, vararg elements: String): String {
-    val totalPages = (totalElements + size - 1) / size
-    val expectedResponse = """
-         {
-          "content": [ ${elements.joinToString(separator = ",")}],
-          "page": {
-            "size": $size,
-            "number": $page,
-            "totalElements": $totalElements,
-            "totalPages": $totalPages
-          }
-        }
-    """.trimIndent()
-    return expectedResponse
-  }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -37,4 +37,11 @@ class JobsGetShould : JobsTestCase() {
       expectedResponse = tescoWarehouseHandlerJobBody,
     )
   }
+
+  @Test
+  fun `retrieve a paginated empty list of Jobs when none registered`() {
+    assertGetJobIsOK(
+      expectedResponse = expectedResponseListOf(),
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGet.kt
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
-import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 
 @Validated
 @RestController
-@RequestMapping("/employers", produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping("/employers", produces = [APPLICATION_JSON_VALUE])
 class EmployersGet(
   private val employerRetriever: EmployerRetriever,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -15,15 +15,18 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 @Validated
 @RestController
 @RequestMapping("/jobs", produces = [APPLICATION_JSON_VALUE])
-class JobsGet(
-  private val jobRetriever: JobRetriever,
-) {
+class JobsGet(private val jobRetriever: JobRetriever) {
+
   @PreAuthorize("hasRole('ROLE_EDUCATION_WORK_PLAN_VIEW') or hasRole('ROLE_EDUCATION_WORK_PLAN_EDIT')")
   @GetMapping("/{id}")
-  fun retrieve(
-    @PathVariable id: String,
-  ): ResponseEntity<GetJobResponse> {
+  fun retrieve(@PathVariable id: String): ResponseEntity<GetJobResponse> {
     val job: Job = jobRetriever.retrieve(id)
     return ResponseEntity.ok().body(GetJobResponse.from(job))
+  }
+
+  @PreAuthorize("hasRole('ROLE_EDUCATION_WORK_PLAN_VIEW') or hasRole('ROLE_EDUCATION_WORK_PLAN_EDIT')")
+  @GetMapping("")
+  fun retrieveAll(): ResponseEntity<Void> {
+    return ResponseEntity.badRequest().build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -26,7 +29,10 @@ class JobsGet(private val jobRetriever: JobRetriever) {
 
   @PreAuthorize("hasRole('ROLE_EDUCATION_WORK_PLAN_VIEW') or hasRole('ROLE_EDUCATION_WORK_PLAN_EDIT')")
   @GetMapping("")
-  fun retrieveAll(): ResponseEntity<Void> {
-    return ResponseEntity.badRequest().build()
+  fun retrieveAll(): ResponseEntity<Page<GetJobResponse>> {
+    val page = 0
+    val size = 10
+    val pageable: Pageable = PageRequest.of(page, size)
+    return ResponseEntity.ok(Page.empty(pageable))
   }
 }


### PR DESCRIPTION
This is a small initial PR for the Jobs list. It implements the minimum test to check that the endpoint wiring is in place and the headers are present.