### PR TITLE
[ESWE-962] Filter jobs by Job title / Employer name AND Job sector

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -164,6 +164,13 @@ abstract class ApplicationTestCase {
     status = "KEY_PARTNER",
   )
 
+  val abcConstructionBody: String = newEmployerBody(
+    name = "ABC Construction",
+    description = "This is a description",
+    sector = "CONSTRUCTION",
+    status = "SILVER",
+  )
+
   protected fun assertAddEmployer(
     id: String? = null,
     body: String,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -66,7 +66,7 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Employers list filtered by sector`() {
+  fun `retrieve a default paginated Employers list filtered by industry sector`() {
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = amazonBody)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
@@ -27,11 +27,15 @@ class EmployersPutShould : EmployerTestCase() {
 
   @Test
   fun `update an existing Employer`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    val uuid = assertAddEmployerIsCreated(body = sainsburysBody)
+    val employerId = assertAddEmployerIsCreated(body = tescoBody)
+
+    assertUpdateEmployerIsOk(
+      employerId = employerId,
+      body = sainsburysBody,
+    )
 
     assertGetEmployerIsOK(
-      employerId = uuid,
+      employerId = employerId,
       expectedResponse = sainsburysBody,
     )
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
@@ -17,6 +17,17 @@ class EmployerTestCase : ApplicationTestCase() {
     )
   }
 
+  protected fun assertUpdateEmployerIsOk(
+    employerId: String,
+    body: String,
+  ): String {
+    return assertAddEmployer(
+      id = employerId,
+      body = body,
+      expectedStatus = OK,
+    )
+  }
+
   protected fun assertAddEmployerThrowsValidationError(
     employerId: String? = null,
     body: String,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
-import java.util.*
 
 class JobsGetShould : JobsTestCase() {
 
@@ -47,26 +46,27 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list`() {
-    givenTwoJobsAreRegistered()
+    givenThreeJobsAreRegistered()
 
     assertGetJobIsOK(
       expectedResponse = expectedResponseListOf(
         amazonForkliftOperatorJobItemListResponse(jobCreationTime),
         tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+        abcConstructionJobItemListResponse(jobCreationTime),
       ),
     )
   }
 
   @Test
   fun `retrieve a custom paginated Jobs list`() {
-    givenTwoJobsAreRegistered()
+    givenThreeJobsAreRegistered()
 
     assertGetJobIsOK(
       parameters = "page=1&size=1",
       expectedResponse = expectedResponseListOf(
         size = 1,
         page = 1,
-        totalElements = 2,
+        totalElements = 3,
         amazonForkliftOperatorJobItemListResponse(jobCreationTime),
       ),
     )
@@ -74,7 +74,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by full Job title`() {
-    givenTwoJobsAreRegistered()
+    givenThreeJobsAreRegistered()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=Forklift operator",
@@ -86,7 +86,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by incomplete Job title`() {
-    givenTwoJobsAreRegistered()
+    givenThreeJobsAreRegistered()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=operator",
@@ -98,7 +98,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by full Employer name`() {
-    givenTwoJobsAreRegistered()
+    givenThreeJobsAreRegistered()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=Tesco",
@@ -110,7 +110,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by incomplete Employer name`() {
-    givenTwoJobsAreRegistered()
+    givenThreeJobsAreRegistered()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=Tes",
@@ -122,7 +122,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by job sector`() {
-    givenTwoJobsAreRegistered()
+    givenThreeJobsAreRegistered()
 
     assertGetJobIsOK(
       parameters = "sector=retail",
@@ -132,7 +132,20 @@ class JobsGetShould : JobsTestCase() {
     )
   }
 
-  private fun givenTwoJobsAreRegistered() {
+  @Test
+  fun `retrieve a default paginated Jobs list filtered by Job title OR Employer name AND job sector`() {
+    givenThreeJobsAreRegistered()
+
+    assertGetJobIsOK(
+      parameters = "jobTitleOrEmployerName=tesco&sector=retail",
+      expectedResponse = expectedResponseListOf(
+        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+      )
+    )
+  }
+
+  private fun givenThreeJobsAreRegistered() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
       body = tescoBody,
@@ -145,12 +158,22 @@ class JobsGetShould : JobsTestCase() {
       expectedStatus = CREATED,
     )
 
+    assertAddEmployer(
+      id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
+      body = abcConstructionBody,
+      expectedStatus = CREATED,
+    )
+
     assertAddJobIsCreated(
       body = tescoWarehouseHandlerJobBody,
     )
 
     assertAddJobIsCreated(
       body = amazonForkliftOperatorJobBody,
+    )
+
+    assertAddJobIsCreated(
+      body = abcConstructionJobBody,
     )
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -120,6 +120,18 @@ class JobsGetShould : JobsTestCase() {
     )
   }
 
+  @Test
+  fun `retrieve a default paginated Jobs list filtered by job sector`() {
+    givenTwoJobsAreRegistered()
+
+    assertGetJobIsOK(
+      parameters = "sector=retail",
+      expectedResponse = expectedResponseListOf(
+        amazonForkliftOperatorJobItemListResponse(jobCreationTime)
+      )
+    )
+  }
+
   private fun givenTwoJobsAreRegistered() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
 
 class JobsGetShould : JobsTestCase() {
-
   @Test
   fun `retrieve an existing Job`() {
     assertAddEmployer(
@@ -141,7 +140,7 @@ class JobsGetShould : JobsTestCase() {
       expectedResponse = expectedResponseListOf(
         tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
         amazonForkliftOperatorJobItemListResponse(jobCreationTime),
-      )
+      ),
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -127,8 +127,8 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobIsOK(
       parameters = "sector=retail",
       expectedResponse = expectedResponseListOf(
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime)
-      )
+        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+      ),
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -157,6 +157,21 @@ class JobsGetShould : JobsTestCase() {
     )
   }
 
+  @Test
+  fun `retrieve a custom paginated Jobs list filtered by Job title OR Employer name AND job sector`() {
+    givenThreeJobsAreRegistered()
+
+    assertGetJobIsOK(
+      parameters = "jobTitleOrEmployerName=Tesco&sector=retail&page=0&size=1",
+      expectedResponse = expectedResponseListOf(
+        size = 1,
+        page = 0,
+        totalElements = 2,
+        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+      ),
+    )
+  }
+
   private fun givenThreeJobsAreRegistered() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -144,6 +144,19 @@ class JobsGetShould : JobsTestCase() {
     )
   }
 
+  @Test
+  fun `retrieve a default paginated Jobs list filtered by incomplete Job title OR Employer name AND job sector`() {
+    givenThreeJobsAreRegistered()
+
+    assertGetJobIsOK(
+      parameters = "jobTitleOrEmployerName=tEs&sector=retail",
+      expectedResponse = expectedResponseListOf(
+        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+      ),
+    )
+  }
+
   private fun givenThreeJobsAreRegistered() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
-import org.springframework.http.HttpStatus.OK
+import java.util.*
 
 class JobsPutShould : JobsTestCase() {
   @Test
@@ -43,15 +43,14 @@ class JobsPutShould : JobsTestCase() {
 
     val jobId = assertAddJobIsCreated(body = amazonForkliftOperatorJobBody)
 
-    assertRequestWithBody(
-      url = "$JOBS_ENDPOINT/$jobId",
-      body = abcConstructionJobBody,
-      expectedStatus = OK,
+    assertUpdateJobIsOk(
+      jobId = jobId,
+      body = amazonForkliftOperatorJobBody,
     )
 
     assertGetJobIsOK(
       jobId = jobId,
-      expectedResponse = abcConstructionJobBody,
+      expectedResponse = amazonForkliftOperatorJobBody,
     )
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -67,11 +67,11 @@ class JobsTestCase : ApplicationTestCase() {
   }
 
   protected val abcConstructionJobBody: String = newJobBody(
-    employerId = "bf392249-b360-4e3e-81a0-8497047987e8",
-    jobTitle = "Warehouse operator",
-    sector = "WAREHOUSING",
+    employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
+    jobTitle = "Apprentice plasterer",
+    sector = "CONSTRUCTION",
     industrySector = "CONSTRUCTION",
-    numberOfVacancies = 1,
+    numberOfVacancies = 3,
     sourcePrimary = "DWP",
     sourceSecondary = "DWP",
     charityName = "dadasdads",
@@ -96,6 +96,48 @@ class JobsTestCase : ApplicationTestCase() {
     isOnlyForPrisonLeavers = true,
     supportingDocumentationRequired = listOf("DISCLOSURE_LETTER", "OTHER"),
     supportingDocumentationDetails = "Some text",
+  )
+
+  protected fun abcConstructionJobResponse(createdAt: Instant): String = newJobResponse(
+    employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
+    jobTitle = "Apprentice plasterer",
+    sector = "CONSTRUCTION",
+    industrySector = "CONSTRUCTION",
+    numberOfVacancies = 3,
+    sourcePrimary = "DWP",
+    sourceSecondary = "DWP",
+    charityName = "dadasdads",
+    postCode = "NE157LR",
+    salaryFrom = 99f,
+    salaryTo = 260f,
+    salaryPeriod = "PER_DAY",
+    additionalSalaryInformation = "10% Performance bonus",
+    isPayingAtLeastNationalMinimumWage = true,
+    workPattern = "FLEXIBLE_SHIFTS",
+    contractType = "TEMPORARY",
+    hoursPerWeek = "FULL_TIME_40_PLUS",
+    baseLocation = "HYBRID",
+    essentialCriteria = "Essential job criteria",
+    desirableCriteria = "Desirable job criteria (optional)",
+    description = "Job description\r\nDescribe the role and main tasks. Include any benefits and training opportunities.",
+    offenceExclusions = listOf("CASE_BY_CASE", "OTHER"),
+    howToApply = "How to applyHow to apply",
+    closingDate = "2025-02-01",
+    startDate = "2025-02-01",
+    isRollingOpportunity = false,
+    isOnlyForPrisonLeavers = true,
+    supportingDocumentationRequired = listOf("DISCLOSURE_LETTER", "OTHER"),
+    supportingDocumentationDetails = "Some text",
+    createdAt = createdAt.toString(),
+  )
+
+  protected fun abcConstructionJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
+    employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
+    employerName = "ABC Construction",
+    jobTitle = "Apprentice plasterer",
+    numberOfVacancies = 3,
+    sector = "CONSTRUCTION",
+    createdAt = createdAt.toString(),
   )
 
   protected val tescoWarehouseHandlerJobBody: String = newJobBody(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -175,7 +175,7 @@ class JobsTestCase : ApplicationTestCase() {
   protected val amazonForkliftOperatorJobBody: String = newJobBody(
     employerId = "bf392249-b360-4e3e-81a0-8497047987e8",
     jobTitle = "Forklift operator",
-    sector = "WAREHOUSING",
+    sector = "RETAIL",
     industrySector = "LOGISTICS",
     numberOfVacancies = 2,
     sourcePrimary = "PEL",
@@ -224,7 +224,7 @@ class JobsTestCase : ApplicationTestCase() {
   protected fun amazonForkliftOperatorJobResponse(createdAt: Instant): String = newJobResponse(
     employerId = "bf392249-b360-4e3e-81a0-8497047987e8",
     jobTitle = "Forklift operator",
-    sector = "WAREHOUSING",
+    sector = "RETAIL",
     industrySector = "LOGISTICS",
     numberOfVacancies = 2,
     sourcePrimary = "PEL",
@@ -276,7 +276,7 @@ class JobsTestCase : ApplicationTestCase() {
     employerName = "Amazon",
     jobTitle = "Forklift operator",
     numberOfVacancies = 2,
-    sector = "WAREHOUSING",
+    sector = "RETAIL",
     createdAt = createdAt.toString(),
   )
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -22,6 +22,17 @@ class JobsTestCase : ApplicationTestCase() {
     )
   }
 
+  protected fun assertUpdateJobIsOk(
+    jobId: String,
+    body: String,
+  ): String {
+    return assertAddJob(
+      jobId = jobId,
+      body = body,
+      expectedStatus = OK,
+    )
+  }
+
   protected fun assertAddJobThrowsValidationError(
     jobId: String? = null,
     body: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -34,13 +34,15 @@ class JobsGet(private val jobRetriever: JobRetriever) {
   fun retrieveAll(
     @RequestParam(required = false)
     jobTitleOrEmployerName: String?,
+    @RequestParam(required = false)
+    sector: String?,
     @RequestParam(defaultValue = "0")
     page: Int,
     @RequestParam(defaultValue = "10")
     size: Int,
   ): ResponseEntity<Page<GetJobsResponse>> {
     val pageable: Pageable = PageRequest.of(page, size)
-    val jobList = jobRetriever.retrieveAllJobs(jobTitleOrEmployerName, pageable)
+    val jobList = jobRetriever.retrieveAllJobs(jobTitleOrEmployerName, sector, pageable)
     val response = jobList.map { GetJobsResponse.from(it) }
     return ResponseEntity.ok(response)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/domain/EmployerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/domain/EmployerRepository.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 @Repository
 interface EmployerRepository : JpaRepository<Employer, EntityId> {
-  fun findByNameIgnoringCaseContaining(name: String?, pageable: Pageable): Page<Employer>
-  fun findBySectorIgnoringCase(sector: String?, pageable: Pageable): Page<Employer>
+  fun findByNameIgnoringCaseContaining(name: String, pageable: Pageable): Page<Employer>
+  fun findBySectorIgnoringCase(sector: String, pageable: Pageable): Page<Employer>
   fun findByNameContainingAndSectorAllIgnoringCase(name: String?, sector: String?, pageable: Pageable): Page<Employer>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
@@ -30,6 +30,13 @@ class JobRetriever(
           sector = sector,
           pageable = pageable,
         )
+      !jobTitleOrEmployerName.isNullOrEmpty() && !sector.isNullOrEmpty() ->
+        jobRepository.findByTitleContainingOrEmployerNameContainingOrSectorAllIgnoringCase(
+          title = jobTitleOrEmployerName,
+          employerName = jobTitleOrEmployerName,
+          sector = sector,
+          pageable = pageable,
+        )
       else -> jobRepository.findAll(pageable)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
@@ -16,15 +16,20 @@ class JobRetriever(
     return jobRepository.findById(EntityId(id)).orElseThrow()
   }
 
-  fun retrieveAllJobs(jobTitleOrEmployerName: String?, pageable: Pageable): Page<Job> {
+  fun retrieveAllJobs(jobTitleOrEmployerName: String?, sector: String?, pageable: Pageable): Page<Job> {
     return when {
-      !jobTitleOrEmployerName.isNullOrEmpty() ->
+      !jobTitleOrEmployerName.isNullOrEmpty() && sector.isNullOrEmpty() ->
         jobRepository
           .findByTitleContainingOrEmployerNameContainingAllIgnoringCase(
             title = jobTitleOrEmployerName,
             employerName = jobTitleOrEmployerName,
             pageable = pageable,
           )
+      jobTitleOrEmployerName.isNullOrEmpty() && !sector.isNullOrEmpty() ->
+        jobRepository.findBySectorIgnoringCase(
+          sector = sector,
+          pageable = pageable,
+        )
       else -> jobRepository.findAll(pageable)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepository.kt
@@ -15,4 +15,10 @@ interface JobRepository : JpaRepository<Job, EntityId> {
   ): Page<Job>
 
   fun findBySectorIgnoringCase(sector: String, pageable: Pageable): Page<Job>
+  fun findByTitleContainingOrEmployerNameContainingOrSectorAllIgnoringCase(
+    title: String,
+    employerName: String,
+    sector: String,
+    pageable: Pageable,
+  ): Page<Job>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepository.kt
@@ -13,4 +13,6 @@ interface JobRepository : JpaRepository<Job, EntityId> {
     employerName: String,
     pageable: Pageable,
   ): Page<Job>
+
+  fun findBySectorIgnoringCase(sector: String, pageable: Pageable): Page<Job>
 }


### PR DESCRIPTION
This PR:
- Allows to filter Jobs list by Job sector
- Allows to filter Jobs list by Job sector AND Job title / Employer name combined. Even if the second one is not complete
- It allows all filtering described combined with custom and default pagination.