### PR TITLE
[ESWE-963] Job list sorted by job title

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -210,6 +210,7 @@ abstract class ApplicationTestCase {
     url: String,
     expectedStatus: HttpStatus,
     expectedResponse: String? = null,
+    expectedJobTitleSortedList: List<String>? = null,
     expectedNameSortedList: List<String>? = null,
     expectedDateSortedList: List<String>? = null,
   ) {
@@ -233,6 +234,11 @@ abstract class ApplicationTestCase {
         expectedNameSortedList?.let {
           jsonPath("$.content[0].name", equalTo(it[0]))
           jsonPath("$.content[1].name", equalTo(it[1]))
+        }
+        expectedJobTitleSortedList?.let {
+          jsonPath("$.content[0].jobTitle", equalTo(it[0]))
+          jsonPath("$.content[1].jobTitle", equalTo(it[1]))
+          jsonPath("$.content[2].jobTitle", equalTo(it[2]))
         }
         expectedDateSortedList?.let {
           jsonPath("$.content[0].createdAt", equalTo(it[0]))

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -116,7 +116,7 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Employers list sorted by name in ascendent order`() {
+  fun `retrieve a default paginated Employers list sorted by name default ascendent`() {
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
@@ -126,7 +126,7 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Employers list sorted by name in descendent order`() {
+  fun `retrieve a default paginated Employers list sorted by name custom descendent`() {
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
-import org.springframework.http.HttpStatus.OK
 
 class JobsGetShould : JobsTestCase() {
   @Test
@@ -168,7 +167,7 @@ class JobsGetShould : JobsTestCase() {
         size = 1,
         page = 0,
         totalElements = 2,
-        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
       ),
     )
   }
@@ -181,8 +180,8 @@ class JobsGetShould : JobsTestCase() {
       expectedJobTitlesSorted = listOf(
         "Apprentice plasterer",
         "Forklift operator",
-        "Warehouse handler"
-      )
+        "Warehouse handler",
+      ),
     )
   }
 
@@ -195,8 +194,8 @@ class JobsGetShould : JobsTestCase() {
       expectedJobTitlesSorted = listOf(
         "Warehouse handler",
         "Forklift operator",
-        "Apprentice plasterer"
-      )
+        "Apprentice plasterer",
+      ),
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.OK
 
 class JobsGetShould : JobsTestCase() {
   @Test
@@ -169,6 +170,19 @@ class JobsGetShould : JobsTestCase() {
         totalElements = 2,
         tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
       ),
+    )
+  }
+
+  @Test
+  fun `retrieve a default paginated Jobs list sorted by job title default ascendent`() {
+    givenThreeJobsAreRegistered()
+
+    assertGetJobIsOKAndSortedByJobTitle(
+      expectedJobTitlesSorted = listOf(
+        "Apprentice plasterer",
+        "Forklift operator",
+        "Warehouse handler"
+      )
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -186,6 +186,20 @@ class JobsGetShould : JobsTestCase() {
     )
   }
 
+  @Test
+  fun `retrieve a default paginated Jobs list sorted by job title custom descendent`() {
+    givenThreeJobsAreRegistered()
+
+    assertGetJobIsOKAndSortedByJobTitle(
+      parameters = "sortBy=jobTitle&sortOrder=desc",
+      expectedJobTitlesSorted = listOf(
+        "Warehouse handler",
+        "Forklift operator",
+        "Apprentice plasterer"
+      )
+    )
+  }
+
   private fun givenThreeJobsAreRegistered() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -79,7 +79,7 @@ class JobsTestCase : ApplicationTestCase() {
 
   protected fun assertGetJobIsOKAndSortedByJobTitle(
     parameters: String? = "",
-    expectedJobTitlesSorted: List<String>
+    expectedJobTitlesSorted: List<String>,
   ) {
     assertResponse(
       url = "$JOBS_ENDPOINT?$parameters",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -78,10 +78,11 @@ class JobsTestCase : ApplicationTestCase() {
   }
 
   protected fun assertGetJobIsOKAndSortedByJobTitle(
+    parameters: String? = "",
     expectedJobTitlesSorted: List<String>
   ) {
     assertResponse(
-      url = JOBS_ENDPOINT,
+      url = "$JOBS_ENDPOINT?$parameters",
       expectedStatus = OK,
       expectedJobTitleSortedList = expectedJobTitlesSorted,
     )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -77,6 +77,16 @@ class JobsTestCase : ApplicationTestCase() {
     )
   }
 
+  protected fun assertGetJobIsOKAndSortedByJobTitle(
+    expectedJobTitlesSorted: List<String>
+  ) {
+    assertResponse(
+      url = JOBS_ENDPOINT,
+      expectedStatus = OK,
+      expectedJobTitleSortedList = expectedJobTitlesSorted,
+    )
+  }
+
   protected val abcConstructionJobBody: String = newJobBody(
     employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
     jobTitle = "Apprentice plasterer",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGet.kt
@@ -107,7 +107,7 @@ class EmployersGet(
     @RequestParam(defaultValue = "10")
     size: Int,
   ): ResponseEntity<Page<GetEmployerResponse>>? {
-    val direction = if(sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
+    val direction = if (sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
     val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortBy))
     val employerList = employerRetriever.retrieveAllEmployers(name, sector, pageable)
     val response = employerList.map { GetEmployerResponse.from(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGet.kt
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction.ASC
+import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -105,7 +107,7 @@ class EmployersGet(
     @RequestParam(defaultValue = "10")
     size: Int,
   ): ResponseEntity<Page<GetEmployerResponse>>? {
-    val direction = if (sortOrder.equals("desc", ignoreCase = true)) Sort.Direction.DESC else Sort.Direction.ASC
+    val direction = if(sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
     val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortBy))
     val employerList = employerRetriever.retrieveAllEmployers(name, sector, pageable)
     val response = employerList.map { GetEmployerResponse.from(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -48,8 +48,12 @@ class JobsGet(private val jobRetriever: JobRetriever) {
     @RequestParam(defaultValue = "10")
     size: Int,
   ): ResponseEntity<Page<GetJobsResponse>> {
+    val sortedBy = when (sortBy) {
+      "jobTitle" -> "title"
+      else -> sortBy
+    }
     val direction = if(sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
-    val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortBy))
+    val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortedBy))
     val jobList = jobRetriever.retrieveAllJobs(jobTitleOrEmployerName, sector, pageable)
     val response = jobList.map { GetJobsResponse.from(it) }
     return ResponseEntity.ok(response)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -52,7 +52,7 @@ class JobsGet(private val jobRetriever: JobRetriever) {
       "jobTitle" -> "title"
       else -> sortBy
     }
-    val direction = if(sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
+    val direction = if (sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
     val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortedBy))
     val jobList = jobRetriever.retrieveAllJobs(jobTitleOrEmployerName, sector, pageable)
     val response = jobList.map { GetJobsResponse.from(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -3,6 +3,9 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction.ASC
+import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -36,12 +39,17 @@ class JobsGet(private val jobRetriever: JobRetriever) {
     jobTitleOrEmployerName: String?,
     @RequestParam(required = false)
     sector: String?,
+    @RequestParam(defaultValue = "title", required = false)
+    sortBy: String?,
+    @RequestParam(defaultValue = "asc", required = false)
+    sortOrder: String?,
     @RequestParam(defaultValue = "0")
     page: Int,
     @RequestParam(defaultValue = "10")
     size: Int,
   ): ResponseEntity<Page<GetJobsResponse>> {
-    val pageable: Pageable = PageRequest.of(page, size)
+    val direction = if(sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
+    val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortBy))
     val jobList = jobRetriever.retrieveAllJobs(jobTitleOrEmployerName, sector, pageable)
     val response = jobList.map { GetJobsResponse.from(it) }
     return ResponseEntity.ok(response)


### PR DESCRIPTION
This PR sets the first field to be sorted, the Job title, and leaves the structure ready for the following field: date added.