### PR TITLE
[ESWE-963] Job list sorted by date added

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -231,18 +231,20 @@ abstract class ApplicationTestCase {
         expectedResponse?.let {
           json(expectedResponse)
         }
-        expectedNameSortedList?.let {
-          jsonPath("$.content[0].name", equalTo(it[0]))
-          jsonPath("$.content[1].name", equalTo(it[1]))
+        expectedNameSortedList?.let { sortedList ->
+          sortedList.forEachIndexed { index, expectedName ->
+            jsonPath("$.content[$index].name", equalTo(expectedName))
+          }
         }
-        expectedJobTitleSortedList?.let {
-          jsonPath("$.content[0].jobTitle", equalTo(it[0]))
-          jsonPath("$.content[1].jobTitle", equalTo(it[1]))
-          jsonPath("$.content[2].jobTitle", equalTo(it[2]))
+        expectedJobTitleSortedList?.let { sortedList ->
+          sortedList.forEachIndexed { index, expectedJobTitle ->
+            jsonPath("$.content[$index].jobTitle", equalTo(expectedJobTitle))
+          }
         }
-        expectedDateSortedList?.let {
-          jsonPath("$.content[0].createdAt", equalTo(it[0]))
-          jsonPath("$.content[1].createdAt", equalTo(it[1]))
+        expectedDateSortedList?.let { sortedList ->
+          sortedList.forEachIndexed { index, expectedDate ->
+            jsonPath("$.content[$index].createdAt", equalTo(expectedDate))
+          }
         }
       }
     }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -116,7 +116,7 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Employers list sorted by name default ascendent`() {
+  fun `retrieve a default paginated Employers list sorted by name, in ascending order, by default`() {
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
@@ -126,7 +126,7 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Employers list sorted by name custom descendent`() {
+  fun `retrieve a default paginated Employers list sorted by name, in descending order`() {
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
@@ -137,7 +137,7 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Employers list sorted by date added in default ascendent order`() {
+  fun `retrieve a default paginated Employers list sorted by creation date, in ascending order, by default`() {
     val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
     whenever(timeProvider.now())
       .thenReturn(fixedTime)
@@ -153,7 +153,7 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Employers list sorted by date added in descendent order`() {
+  fun `retrieve a default paginated Employers list sorted by creation date, in descending order`() {
     val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
     whenever(timeProvider.now())
       .thenReturn(fixedTime)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -175,7 +175,7 @@ class JobsGetShould : JobsTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Jobs list sorted by job title default ascendent`() {
+  fun `retrieve a default paginated Jobs list sorted by job title, in ascending order, by default`() {
     givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByJobTitle(
@@ -188,7 +188,7 @@ class JobsGetShould : JobsTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Jobs list sorted by job title custom descendent`() {
+  fun `retrieve a default paginated Jobs list sorted by job title in, descending order`() {
     givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByJobTitle(
@@ -202,7 +202,7 @@ class JobsGetShould : JobsTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Jobs list sorted by date added default ascendent`() {
+  fun `retrieve a default paginated Jobs list sorted by creation date, in ascending order, by default`() {
     givenJobsMustHaveDifferentCreationTimes()
 
     givenThreeJobsAreCreated()
@@ -218,7 +218,7 @@ class JobsGetShould : JobsTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Jobs list sorted by date added custom descendent`() {
+  fun `retrieve a default paginated Jobs list sorted by creation date, in descending order`() {
     givenJobsMustHaveDifferentCreationTimes()
 
     givenThreeJobsAreCreated()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -47,7 +47,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       expectedResponse = expectedResponseListOf(
@@ -60,7 +60,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a custom paginated Jobs list`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "page=1&size=1",
@@ -75,7 +75,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by full Job title`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=Forklift operator",
@@ -87,7 +87,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by incomplete Job title`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=operator",
@@ -99,7 +99,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by full Employer name`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=Tesco",
@@ -111,7 +111,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by incomplete Employer name`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=Tes",
@@ -123,7 +123,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by job sector`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "sector=retail",
@@ -135,7 +135,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by Job title OR Employer name AND job sector`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=tesco&sector=retail",
@@ -148,7 +148,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list filtered by incomplete Job title OR Employer name AND job sector`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=tEs&sector=retail",
@@ -161,7 +161,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a custom paginated Jobs list filtered by Job title OR Employer name AND job sector`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=Tesco&sector=retail&page=0&size=1",
@@ -176,7 +176,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list sorted by job title default ascendent`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByJobTitle(
       expectedJobTitlesSorted = listOf(
@@ -189,7 +189,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list sorted by job title custom descendent`() {
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByJobTitle(
       parameters = "sortBy=jobTitle&sortOrder=desc",
@@ -203,12 +203,9 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list sorted by date added default ascendent`() {
-    whenever(dateTimeProvider.now)
-      .thenReturn(Optional.of(jobCreationTime))
-      .thenReturn(Optional.of(jobCreationTime.plusSeconds(10)))
-      .thenReturn(Optional.of(jobCreationTime.plusSeconds(20)))
+    givenJobsMustHaveDifferentCreationTimes()
 
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByDate(
       parameters = "sortBy=createdAt",
@@ -222,12 +219,9 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve a default paginated Jobs list sorted by date added custom descendent`() {
-    whenever(dateTimeProvider.now)
-      .thenReturn(Optional.of(jobCreationTime))
-      .thenReturn(Optional.of(jobCreationTime.plusSeconds(10)))
-      .thenReturn(Optional.of(jobCreationTime.plusSeconds(20)))
+    givenJobsMustHaveDifferentCreationTimes()
 
-    givenThreeJobsAreRegistered()
+    givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=desc",
@@ -239,7 +233,14 @@ class JobsGetShould : JobsTestCase() {
     )
   }
 
-  private fun givenThreeJobsAreRegistered() {
+  private fun givenJobsMustHaveDifferentCreationTimes() {
+    whenever(dateTimeProvider.now)
+      .thenReturn(Optional.of(jobCreationTime))
+      .thenReturn(Optional.of(jobCreationTime.plusSeconds(10)))
+      .thenReturn(Optional.of(jobCreationTime.plusSeconds(20)))
+  }
+
+  private fun givenThreeJobsAreCreated() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
       body = tescoBody,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -220,6 +220,25 @@ class JobsGetShould : JobsTestCase() {
     )
   }
 
+  @Test
+  fun `retrieve a default paginated Jobs list sorted by date added custom descendent`() {
+    whenever(dateTimeProvider.now)
+      .thenReturn(Optional.of(jobCreationTime))
+      .thenReturn(Optional.of(jobCreationTime.plusSeconds(10)))
+      .thenReturn(Optional.of(jobCreationTime.plusSeconds(20)))
+
+    givenThreeJobsAreRegistered()
+
+    assertGetJobIsOKAndSortedByDate(
+      parameters = "sortBy=createdAt&sortOrder=desc",
+      expectedDatesSorted = listOf(
+        "2024-01-01T00:00:20Z",
+        "2024-01-01T00:00:10Z",
+        "2024-01-01T00:00:00Z",
+      ),
+    )
+  }
+
   private fun givenThreeJobsAreRegistered() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus.CREATED
+import java.util.*
 
 class JobsGetShould : JobsTestCase() {
   @Test
@@ -195,6 +197,25 @@ class JobsGetShould : JobsTestCase() {
         "Warehouse handler",
         "Forklift operator",
         "Apprentice plasterer",
+      ),
+    )
+  }
+
+  @Test
+  fun `retrieve a default paginated Jobs list sorted by date added default ascendent`() {
+    whenever(dateTimeProvider.now)
+      .thenReturn(Optional.of(jobCreationTime))
+      .thenReturn(Optional.of(jobCreationTime.plusSeconds(10)))
+      .thenReturn(Optional.of(jobCreationTime.plusSeconds(20)))
+
+    givenThreeJobsAreRegistered()
+
+    assertGetJobIsOKAndSortedByDate(
+      parameters = "sortBy=createdAt",
+      expectedDatesSorted = listOf(
+        "2024-01-01T00:00:00Z",
+        "2024-01-01T00:00:10Z",
+        "2024-01-01T00:00:20Z",
       ),
     )
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -88,6 +88,17 @@ class JobsTestCase : ApplicationTestCase() {
     )
   }
 
+  protected fun assertGetJobIsOKAndSortedByDate(
+    parameters: String? = null,
+    expectedDatesSorted: List<String>,
+  ) {
+    assertResponse(
+      url = "$JOBS_ENDPOINT?$parameters",
+      expectedStatus = OK,
+      expectedDateSortedList = expectedDatesSorted,
+    )
+  }
+
   protected val abcConstructionJobBody: String = newJobBody(
     employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
     jobTitle = "Apprentice plasterer",


### PR DESCRIPTION
This PR checks that:
-  When `sortedBy` is passed as a parameter with the value `createdAt`:
   - If the value for the `sortOrder` parameter is empty or missing, it will be `asc` by default, meaning that the job list will be sorted by the creation date (`createdAt`) in ascending order.
   - If the value for the `sortOrder` parameter has a `desc` value, the job list will be sorted by the creation date (`createdAt`) in descending order.