### PR TITLE
[ESWE-963] Adds missing tests for explicit ascending sorting

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -126,6 +126,17 @@ class EmployersGetShould : EmployerTestCase() {
   }
 
   @Test
+  fun `retrieve a default paginated Employers list sorted by name, in ascending order`() {
+    assertAddEmployerIsCreated(body = tescoBody)
+    assertAddEmployerIsCreated(body = sainsburysBody)
+
+    assertGetEmployersIsOKAndSortedByName(
+      parameters = "sortBy=name&sortOrder=asc",
+      expectedNamesSorted = listOf("Sainsbury's", "Tesco"),
+    )
+  }
+
+  @Test
   fun `retrieve a default paginated Employers list sorted by name, in descending order`() {
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
@@ -148,6 +159,22 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt",
+      expectedDatesSorted = listOf("2024-07-01T01:00:00", "2024-07-02T01:00:00"),
+    )
+  }
+
+  @Test
+  fun `retrieve a default paginated Employers list sorted by creation date, in ascending order`() {
+    val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
+    whenever(timeProvider.now())
+      .thenReturn(fixedTime)
+      .thenReturn(fixedTime.plusDays(1))
+
+    assertAddEmployerIsCreated(body = tescoBody)
+    assertAddEmployerIsCreated(body = sainsburysBody)
+
+    assertGetEmployersIsOkAndSortedByDate(
+      parameters = "sortBy=createdAt&sortOrder=asc",
       expectedDatesSorted = listOf("2024-07-01T01:00:00", "2024-07-02T01:00:00"),
     )
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -188,6 +188,20 @@ class JobsGetShould : JobsTestCase() {
   }
 
   @Test
+  fun `retrieve a default paginated Jobs list sorted by job title, in ascending order`() {
+    givenThreeJobsAreCreated()
+
+    assertGetJobIsOKAndSortedByJobTitle(
+      parameters = "sortBy=jobTitle&sortOrder=asc",
+      expectedJobTitlesSorted = listOf(
+        "Apprentice plasterer",
+        "Forklift operator",
+        "Warehouse handler",
+      ),
+    )
+  }
+
+  @Test
   fun `retrieve a default paginated Jobs list sorted by job title in, descending order`() {
     givenThreeJobsAreCreated()
 
@@ -209,6 +223,22 @@ class JobsGetShould : JobsTestCase() {
 
     assertGetJobIsOKAndSortedByDate(
       parameters = "sortBy=createdAt",
+      expectedDatesSorted = listOf(
+        "2024-01-01T00:00:00Z",
+        "2024-01-01T00:00:10Z",
+        "2024-01-01T00:00:20Z",
+      ),
+    )
+  }
+
+  @Test
+  fun `retrieve a default paginated Jobs list sorted by creation date, in ascending order`() {
+    givenJobsMustHaveDifferentCreationTimes()
+
+    givenThreeJobsAreCreated()
+
+    assertGetJobIsOKAndSortedByDate(
+      parameters = "sortBy=createdAt&sortOrder=asc",
       expectedDatesSorted = listOf(
         "2024-01-01T00:00:00Z",
         "2024-01-01T00:00:10Z",


### PR DESCRIPTION
This small PR amends the previous one, adding missing tests for the Job and Employer list.

These new tests will check that the list works correctly even if the default ascending sorting option is explicitly passed.