### PR TITLE
[ESWE-962] Fixes the jobs list filter logic

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -155,10 +155,7 @@ class JobsGetShould : JobsTestCase() {
 
     assertGetJobIsOK(
       parameters = "jobTitleOrEmployerName=tesco&sector=retail",
-      expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
-      ),
+      expectedResponse = expectedResponseListOf(),
     )
   }
 
@@ -167,10 +164,9 @@ class JobsGetShould : JobsTestCase() {
     givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
-      parameters = "jobTitleOrEmployerName=tEs&sector=retail",
+      parameters = "jobTitleOrEmployerName=er&sector=construction",
       expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+        abcConstructionJobItemListResponse(jobCreationTime),
       ),
     )
   }
@@ -180,12 +176,12 @@ class JobsGetShould : JobsTestCase() {
     givenThreeJobsAreCreated()
 
     assertGetJobIsOK(
-      parameters = "jobTitleOrEmployerName=Tesco&sector=retail&page=0&size=1",
+      parameters = "jobTitleOrEmployerName=Tesco&sector=warehousing&page=0&size=1",
       expectedResponse = expectedResponseListOf(
         size = 1,
         page = 0,
-        totalElements = 2,
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+        totalElements = 1,
+        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
@@ -31,9 +31,8 @@ class JobRetriever(
           pageable = pageable,
         )
       !jobTitleOrEmployerName.isNullOrEmpty() && !sector.isNullOrEmpty() ->
-        jobRepository.findByTitleContainingOrEmployerNameContainingOrSectorAllIgnoringCase(
-          title = jobTitleOrEmployerName,
-          employerName = jobTitleOrEmployerName,
+        jobRepository.findBySectorAndTitleOrEmployerName(
+          searchString = jobTitleOrEmployerName,
           sector = sector,
           pageable = pageable,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Job.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Job.kt
@@ -64,7 +64,6 @@ data class Job(
   @Column(name = "contract_type", nullable = false)
   val contractType: String,
 
-  // TODO: this field must be optional
   @Column(name = "base_location", nullable = true)
   val baseLocation: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepository.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
@@ -15,10 +17,19 @@ interface JobRepository : JpaRepository<Job, EntityId> {
   ): Page<Job>
 
   fun findBySectorIgnoringCase(sector: String, pageable: Pageable): Page<Job>
-  fun findByTitleContainingOrEmployerNameContainingOrSectorAllIgnoringCase(
-    title: String,
-    employerName: String,
-    sector: String,
+
+  @Query(
+    """
+    SELECT j FROM Job j
+    WHERE LOWER(j.sector) = LOWER(:sector)
+    AND (LOWER(j.title) LIKE LOWER(CONCAT('%', :searchString, '%'))
+        OR LOWER(j.employer.name) LIKE LOWER(CONCAT('%', :searchString, '%'))
+    )
+  """,
+  )
+  fun findBySectorAndTitleOrEmployerName(
+    @Param("searchString") searchString: String,
+    @Param("sector") sector: String,
     pageable: Pageable,
   ): Page<Job>
 }


### PR DESCRIPTION
The expected logic condition of the Jobs list search must be:

`Job sector AND (JobTitle OR Employer name)`

However, the result was not expected because of the limitations of the JPA Query Methods. We observed instead the following behaviour:

`Job sector AND JobTitle OR Employer name`

The existing tests didn't catch the unexpected behaviour and also needed a revisit.

This PR fixes the logic and the tests. It replaces the existing JPA Query Method with a more specific Spring Data JPA @Query that allows the desired logic condition.