### PR TITLE
[ESWE-942] Add/Revise audit fields of Employer

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api
 
+import com.jayway.jsonpath.JsonPath
 import org.awaitility.Awaitility
 import org.flywaydb.core.Flyway
+import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -40,6 +42,8 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
 import uk.gov.justice.digital.hmpps.jobsboard.api.time.DefaultTimeProvider
 import java.time.Instant
+import java.time.Period
+import java.time.ZonedDateTime
 import java.util.*
 import java.util.UUID.randomUUID
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -81,8 +85,9 @@ abstract class ApplicationTestCase {
   @Autowired
   private lateinit var jwtAuthHelper: JwtAuthHelper
 
-  val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
-  val employerCreationTime = Instant.parse("2024-07-01T01:00:00Z")
+  private val countOfGettingCurrentTime = intArrayOf(0)
+
+  val defaultCurrentTime = Instant.parse("2024-01-01T00:00:00Z")
 
   companion object {
     private val postgresContainer = PostgresContainer.flywayContainer
@@ -116,7 +121,8 @@ abstract class ApplicationTestCase {
   @BeforeEach
   fun setup() {
     whenever(timeProvider.now()).thenCallRealMethod()
-    whenever(dateTimeProvider.now).thenReturn(Optional.of(jobCreationTime))
+    whenever(dateTimeProvider.now).thenReturn(Optional.of(defaultCurrentTime))
+    countOfGettingCurrentTime[0] = 0
   }
 
   internal fun setAuthorisation(
@@ -214,6 +220,7 @@ abstract class ApplicationTestCase {
     expectedJobTitleSortedList: List<String>? = null,
     expectedNameSortedList: List<String>? = null,
     expectedDateSortedList: List<String>? = null,
+    expectedDateSortingOrder: String? = null,
   ) {
     val resultActions = mockMvc.get(url) {
       contentType = APPLICATION_JSON
@@ -225,7 +232,8 @@ abstract class ApplicationTestCase {
           }
         }
       }
-    }.andExpect {
+    }
+    resultActions.andExpect {
       status { isEqualTo(expectedStatus.value()) }
       content {
         contentType(APPLICATION_JSON)
@@ -245,6 +253,28 @@ abstract class ApplicationTestCase {
         expectedDateSortedList?.let { sortedList ->
           sortedList.forEachIndexed { index, expectedDate ->
             jsonPath("$.content[$index].createdAt", equalTo(expectedDate))
+          }
+        }
+        expectedDateSortingOrder?.let { sortingOrder ->
+          val timestamps = (
+            JsonPath.parse(resultActions.andReturn().response.contentAsString)
+              .read("$.content[*].createdAt") as List<String>
+            ).map { timestamp ->
+            ZonedDateTime.parse(timestamp).toInstant()
+          }.run {
+            when (sortingOrder) {
+              "asc" -> this.sorted()
+              "desc" -> this.sortedDescending()
+              else -> this
+            }
+          }.map { instant ->
+            instant.toString()
+          }.toTypedArray()
+
+          resultActions.andExpect {
+            content {
+              jsonPath("$.content[*].createdAt", contains(*timestamps))
+            }
           }
         }
       }
@@ -273,5 +303,15 @@ abstract class ApplicationTestCase {
         }
     """.trimIndent()
     return expectedResponse
+  }
+
+  protected fun givenCurrentTimeIsStrictlyIncreasing(startTime: Instant) {
+    whenever(dateTimeProvider.now)
+      .thenAnswer { Optional.of(startTime.plusSeconds((this.countOfGettingCurrentTime[0]++ * 10).toLong())) }
+  }
+
+  protected fun givenCurrentTimeIsStrictlyIncreasingIncrementByDay(startTime: Instant) {
+    whenever(dateTimeProvider.now)
+      .thenAnswer { Optional.of(startTime.plus(Period.ofDays(this.countOfGettingCurrentTime[0]++))) }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -82,6 +82,7 @@ abstract class ApplicationTestCase {
   private lateinit var jwtAuthHelper: JwtAuthHelper
 
   val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
+  val employerCreationTime = Instant.parse("2024-07-01T01:00:00Z")
 
   companion object {
     private val postgresContainer = PostgresContainer.flywayContainer

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerRepositoryShould.kt
@@ -1,26 +1,32 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.auditing.DateTimeProvider
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.jobsboard.api.config.TestJpaConfig
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
-import java.time.LocalDateTime
+import java.time.Instant
 import java.util.*
 
 @DataJpaTest
+@Import(TestJpaConfig::class)
 @AutoConfigureTestDatabase(replace = NONE)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test-containers")
@@ -28,7 +34,13 @@ import java.util.*
 class EmployerRepositoryShould {
 
   @Autowired
+  private lateinit var dateTimeProvider: DateTimeProvider
+
+  @Autowired
   lateinit var employerRepository: EmployerRepository
+
+  val employerCreationTime = Instant.parse("2024-07-01T01:00:00Z")
+  val employerModificationTime = Instant.parse("2024-07-01T02:00:00Z")
 
   private lateinit var employer: Employer
 
@@ -42,8 +54,8 @@ class EmployerRepositoryShould {
         description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
         sector = "sector",
         status = "status",
-        createdAt = LocalDateTime.parse("2024-05-16T11:15:04.915205"),
       )
+    whenever(dateTimeProvider.now).thenReturn(Optional.of(employerCreationTime))
   }
 
   companion object {
@@ -78,5 +90,39 @@ class EmployerRepositoryShould {
   @Test
   fun `not find a non existing Employer`() {
     assertFalse(employerRepository.findById(EntityId("be756fdd-8258-4561-88db-6fbd84295411")).isPresent)
+  }
+
+  @Test
+  fun `set createdAt attribute when saving a new employer`() {
+    val savedEmployer = employerRepository.save(employer)
+
+    assertThat(savedEmployer.createdAt).isEqualTo(employerCreationTime)
+  }
+
+  @Test
+  fun `not update createdAt attribute when updating an existing Employer`() {
+    val savedEmployer = employerRepository.save(employer)
+
+    whenever(dateTimeProvider.now).thenReturn(Optional.of(employerModificationTime))
+    val updatedJEmployer = employerRepository.save(savedEmployer)
+
+    assertThat(updatedJEmployer.createdAt).isEqualTo(employerCreationTime)
+  }
+
+  @Test
+  fun `set modifiedAt attribute with same value as createdAt when saving a new Employer`() {
+    val savedEmployer = employerRepository.save(employer)
+
+    assertThat(savedEmployer.modifiedAt).isEqualTo(employerCreationTime)
+  }
+
+  @Test
+  fun `update modifiedAt attribute with current date and time when updating an existing Employer`() {
+    val savedEmployer = employerRepository.save(employer)
+
+    whenever(dateTimeProvider.now).thenReturn(Optional.of(employerModificationTime))
+    val updatedEmployer = employerRepository.saveAndFlush(savedEmployer)
+
+    assertThat(updatedEmployer.modifiedAt).isEqualTo(employerModificationTime)
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/JobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/JobRepositoryShould.kt
@@ -55,7 +55,6 @@ class JobRepositoryShould {
     description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
     sector = "LOGISTICS",
     status = "KEY_PARTNER",
-    createdAt = employerFixedTime,
   )
 
   private val amazonForkliftOperatorJob = Job(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/JobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/JobRepositoryShould.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.Month.JULY
 import java.util.*
 
@@ -45,7 +44,6 @@ class JobRepositoryShould {
   @Autowired
   private lateinit var jobRepository: JobRepository
 
-  private val employerFixedTime = LocalDateTime.of(2024, JULY, 20, 22, 6)
   private val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
   private val jobModificationTime = Instant.parse("2025-02-02T01:00:00Z")
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -2,7 +2,8 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
-import java.time.LocalDateTime
+import java.time.Period
+import java.util.*
 
 class EmployersGetShould : EmployerTestCase() {
   @Test
@@ -149,49 +150,46 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order, by default`() {
-    val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
-    whenever(timeProvider.now())
-      .thenReturn(fixedTime)
-      .thenReturn(fixedTime.plusDays(1))
+    givenEmployersMustHaveDifferentCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt",
-      expectedDatesSorted = listOf("2024-07-01T01:00:00", "2024-07-02T01:00:00"),
+      expectedDatesSorted = listOf("2024-07-01T01:00:00Z", "2024-07-02T01:00:00Z"),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order`() {
-    val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
-    whenever(timeProvider.now())
-      .thenReturn(fixedTime)
-      .thenReturn(fixedTime.plusDays(1))
+    givenEmployersMustHaveDifferentCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=asc",
-      expectedDatesSorted = listOf("2024-07-01T01:00:00", "2024-07-02T01:00:00"),
+      expectedDatesSorted = listOf("2024-07-01T01:00:00Z", "2024-07-02T01:00:00Z"),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in descending order`() {
-    val fixedTime = LocalDateTime.of(2024, 7, 1, 1, 0, 0)
-    whenever(timeProvider.now())
-      .thenReturn(fixedTime)
-      .thenReturn(fixedTime.plusDays(1))
+    givenEmployersMustHaveDifferentCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=desc",
-      expectedDatesSorted = listOf("2024-07-02T01:00:00", "2024-07-01T01:00:00"),
+      expectedDatesSorted = listOf("2024-07-02T01:00:00Z", "2024-07-01T01:00:00Z"),
     )
+  }
+
+  private fun givenEmployersMustHaveDifferentCreationTimes() {
+    whenever(dateTimeProvider.now)
+      .thenReturn(Optional.of(employerCreationTime))
+      .thenReturn(Optional.of(employerCreationTime.plus(Period.ofDays(1))))
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -147,7 +147,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order, by default`() {
-    givenEmployersMustHaveDifferentCreationTimes()
+    givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
@@ -161,7 +161,7 @@ class EmployersGetShould : EmployerTestCase() {
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order`() {
     val sortingOrder = "asc"
-    givenEmployersMustHaveDifferentCreationTimes()
+    givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
@@ -175,7 +175,7 @@ class EmployersGetShould : EmployerTestCase() {
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in descending order`() {
     val sortingOrder = "desc"
-    givenEmployersMustHaveDifferentCreationTimes()
+    givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
@@ -186,7 +186,7 @@ class EmployersGetShould : EmployerTestCase() {
     )
   }
 
-  private fun givenEmployersMustHaveDifferentCreationTimes() {
+  private fun givenEmployersHaveIncreasingIncrementByDayCreationTimes() {
     givenCurrentTimeIsStrictlyIncreasingIncrementByDay(employerCreationTime)
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.whenever
-import java.time.Period
-import java.util.*
 
 class EmployersGetShould : EmployerTestCase() {
   @Test
@@ -157,39 +154,39 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt",
-      expectedDatesSorted = listOf("2024-07-01T01:00:00Z", "2024-07-02T01:00:00Z"),
+      expectedSortingOrder = "asc",
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order`() {
+    val sortingOrder = "asc"
     givenEmployersMustHaveDifferentCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
     assertGetEmployersIsOkAndSortedByDate(
-      parameters = "sortBy=createdAt&sortOrder=asc",
-      expectedDatesSorted = listOf("2024-07-01T01:00:00Z", "2024-07-02T01:00:00Z"),
+      parameters = "sortBy=createdAt&sortOrder=$sortingOrder",
+      expectedSortingOrder = sortingOrder,
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in descending order`() {
+    val sortingOrder = "desc"
     givenEmployersMustHaveDifferentCreationTimes()
 
     assertAddEmployerIsCreated(body = tescoBody)
     assertAddEmployerIsCreated(body = sainsburysBody)
 
     assertGetEmployersIsOkAndSortedByDate(
-      parameters = "sortBy=createdAt&sortOrder=desc",
-      expectedDatesSorted = listOf("2024-07-02T01:00:00Z", "2024-07-01T01:00:00Z"),
+      parameters = "sortBy=createdAt&sortOrder=$sortingOrder",
+      expectedSortingOrder = sortingOrder,
     )
   }
 
   private fun givenEmployersMustHaveDifferentCreationTimes() {
-    whenever(dateTimeProvider.now)
-      .thenReturn(Optional.of(employerCreationTime))
-      .thenReturn(Optional.of(employerCreationTime.plus(Period.ofDays(1))))
+    givenCurrentTimeIsStrictlyIncreasingIncrementByDay(employerCreationTime)
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
@@ -4,10 +4,13 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
+import java.time.Instant
 
 const val EMPLOYERS_ENDPOINT = "/employers"
 
 class EmployerTestCase : ApplicationTestCase() {
+  val employerCreationTime = Instant.parse("2024-07-01T01:00:00Z")
+
   protected fun assertAddEmployerIsCreated(
     body: String,
   ): String {
@@ -75,6 +78,17 @@ class EmployerTestCase : ApplicationTestCase() {
       url = "$EMPLOYERS_ENDPOINT?$parameters",
       expectedStatus = OK,
       expectedDateSortedList = expectedDatesSorted,
+    )
+  }
+
+  protected fun assertGetEmployersIsOkAndSortedByDate(
+    parameters: String,
+    expectedSortingOrder: String = "asc",
+  ) {
+    assertResponse(
+      url = "$EMPLOYERS_ENDPOINT?$parameters",
+      expectedStatus = OK,
+      expectedDateSortingOrder = expectedSortingOrder,
     )
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -1,9 +1,7 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus.CREATED
-import java.util.*
 
 class JobsGetShould : JobsTestCase() {
   @Test
@@ -214,7 +212,7 @@ class JobsGetShould : JobsTestCase() {
   }
 
   @Test
-  fun `retrieve a default paginated Jobs list sorted by job title in, descending order`() {
+  fun `retrieve a default paginated Jobs list sorted by job title, in descending order`() {
     givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByJobTitle(
@@ -235,54 +233,38 @@ class JobsGetShould : JobsTestCase() {
 
     assertGetJobIsOKAndSortedByDate(
       parameters = "sortBy=createdAt",
-      expectedDatesSorted = listOf(
-        "2024-01-01T00:00:00Z",
-        "2024-01-01T00:00:10Z",
-        "2024-01-01T00:00:20Z",
-      ),
+      expectedSortingOrder = "asc",
     )
   }
 
   @Test
   fun `retrieve a default paginated Jobs list sorted by creation date, in ascending order`() {
+    val sortingOrder = "asc"
     givenJobsMustHaveDifferentCreationTimes()
 
     givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByDate(
-      parameters = "sortBy=createdAt&sortOrder=asc",
-      expectedDatesSorted = listOf(
-        "2024-01-01T00:00:00Z",
-        "2024-01-01T00:00:10Z",
-        "2024-01-01T00:00:20Z",
-      ),
+      parameters = "sortBy=createdAt&sortOrder=$sortingOrder",
+      expectedSortingOrder = sortingOrder,
     )
   }
 
   @Test
   fun `retrieve a default paginated Jobs list sorted by creation date, in descending order`() {
+    val sortingOrder = "desc"
     givenJobsMustHaveDifferentCreationTimes()
 
     givenThreeJobsAreCreated()
 
     assertGetJobIsOKAndSortedByDate(
-      parameters = "sortBy=createdAt&sortOrder=desc",
-      expectedDatesSorted = listOf(
-        "2024-01-01T00:00:20Z",
-        "2024-01-01T00:00:10Z",
-        "2024-01-01T00:00:00Z",
-      ),
+      parameters = "sortBy=createdAt&sortOrder=$sortingOrder",
+      expectedSortingOrder = sortingOrder,
     )
   }
 
   private fun givenJobsMustHaveDifferentCreationTimes() {
-    whenever(dateTimeProvider.now)
-      .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))
-      .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))
-      .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))
-      .thenReturn(Optional.of(jobCreationTime))
-      .thenReturn(Optional.of(jobCreationTime.plusSeconds(10)))
-      .thenReturn(Optional.of(jobCreationTime.plusSeconds(20)))
+    givenCurrentTimeIsStrictlyIncreasing(jobCreationTime)
   }
 
   private fun givenThreeJobsAreCreated() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -276,7 +276,11 @@ class JobsGetShould : JobsTestCase() {
   }
 
   private fun givenJobsMustHaveDifferentCreationTimes() {
+    // Each employer creation call it twice (createdAt, modifiedAt); i.e. 3*2=6 times before job creations
     whenever(dateTimeProvider.now)
+      .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))
+      .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))
+      .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))
       .thenReturn(Optional.of(jobCreationTime))
       .thenReturn(Optional.of(jobCreationTime.plusSeconds(10)))
       .thenReturn(Optional.of(jobCreationTime.plusSeconds(20)))

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -276,7 +276,6 @@ class JobsGetShould : JobsTestCase() {
   }
 
   private fun givenJobsMustHaveDifferentCreationTimes() {
-    // Each employer creation call it twice (createdAt, modifiedAt); i.e. 3*2=6 times before job creations
     whenever(dateTimeProvider.now)
       .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))
       .thenReturn(Optional.of(employerCreationTime), Optional.of(employerCreationTime))

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -2,17 +2,28 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
 import java.time.Instant
+import java.util.Optional
 import java.util.UUID.randomUUID
 
 const val JOBS_ENDPOINT = "/jobs"
 
 class JobsTestCase : ApplicationTestCase() {
+  val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
+
+  @BeforeEach
+  override fun setup() {
+    super.setup()
+    whenever(dateTimeProvider.now).thenReturn(Optional.of(jobCreationTime))
+  }
+
   protected fun assertAddJobIsCreated(
     body: String,
   ): String {
@@ -96,6 +107,17 @@ class JobsTestCase : ApplicationTestCase() {
       url = "$JOBS_ENDPOINT?$parameters",
       expectedStatus = OK,
       expectedDateSortedList = expectedDatesSorted,
+    )
+  }
+
+  protected fun assertGetJobIsOKAndSortedByDate(
+    parameters: String? = null,
+    expectedSortingOrder: String = "asc",
+  ) {
+    assertResponse(
+      url = "$JOBS_ENDPOINT?$parameters",
+      expectedStatus = OK,
+      expectedDateSortingOrder = expectedSortingOrder,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreator.kt
@@ -4,12 +4,10 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
-import uk.gov.justice.digital.hmpps.jobsboard.api.time.TimeProvider
 
 @Service
 class EmployerCreator(
   private val employerRepository: EmployerRepository,
-  private val timeProvider: TimeProvider,
 ) {
   fun createOrUpdate(
     request: CreateEmployerRequest,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreator.kt
@@ -21,7 +21,6 @@ class EmployerCreator(
         description = request.description,
         sector = request.sector,
         status = request.status,
-        createdAt = timeProvider.now(),
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/GetEmployerResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/GetEmployerResponse.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.employers.application
 
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
-import java.time.LocalDateTime
 
 data class GetEmployerResponse(
   val id: String,
@@ -9,7 +8,7 @@ data class GetEmployerResponse(
   val description: String,
   val sector: String,
   val status: String,
-  val createdAt: LocalDateTime,
+  val createdAt: String,
 ) {
   companion object {
     fun from(employer: Employer): GetEmployerResponse {
@@ -19,7 +18,7 @@ data class GetEmployerResponse(
         description = employer.description,
         sector = employer.sector,
         status = employer.status,
-        createdAt = employer.createdAt,
+        createdAt = employer.createdAt.toString(),
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/domain/Employer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/domain/Employer.kt
@@ -7,8 +7,8 @@ import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Auditable
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "employers")
@@ -28,9 +28,6 @@ data class Employer(
   @Column(name = "status", nullable = false)
   val status: String,
 
-  @Column(name = "created_at", nullable = false)
-  var createdAt: LocalDateTime,
-
   @OneToMany(mappedBy = "employer", cascade = [CascadeType.ALL], orphanRemoval = true)
   val jobs: List<Job> = mutableListOf(),
-)
+) : Auditable()

--- a/src/main/resources/db/migration/V1_1__start.sql
+++ b/src/main/resources/db/migration/V1_1__start.sql
@@ -4,7 +4,8 @@ create table if not exists employers (
     description varchar(500) NOT NULL,
     sector varchar(255) NOT NULL,
     status varchar(255) NOT NULL,
-    created_at timestamp(6) NOT NULL
+    created_at timestamp(6) NOT NULL,
+    modified_at timestamp(6) NOT NULL
 );
 
 create table if not exists jobs(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreatorShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreatorShould.kt
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
@@ -15,15 +13,11 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.TestBase
-import uk.gov.justice.digital.hmpps.jobsboard.api.time.TimeProvider
 import java.util.*
 import kotlin.test.Test
 
 @ExtendWith(MockitoExtension::class)
 class EmployerCreatorShould : TestBase() {
-
-  @Mock
-  private val timeProvider: TimeProvider = mock(TimeProvider::class.java)
 
   @InjectMocks
   private lateinit var employerCreator: EmployerCreator

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreatorShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerCreatorShould.kt
@@ -42,7 +42,6 @@ class EmployerCreatorShould : TestBase() {
     description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
     sector = "RETAIL",
     status = "GOLD",
-    createdAt = fixedTime,
   )
 
   private val expectedEmployer = sainsburysEmployer
@@ -65,7 +64,6 @@ class EmployerCreatorShould : TestBase() {
 
   @Test
   fun `save an Employer with valid details`() {
-    whenever(timeProvider.now()).thenReturn(fixedTime)
     employerCreator.createOrUpdate(createEmployerRequest)
 
     val employerCaptor = argumentCaptor<Employer>()
@@ -81,7 +79,6 @@ class EmployerCreatorShould : TestBase() {
 
   @Test
   fun `save an Employer with current time`() {
-    whenever(timeProvider.now()).thenReturn(fixedTime)
     employerCreator.createOrUpdate(createEmployerRequest)
 
     val employerCaptor = argumentCaptor<Employer>()
@@ -89,6 +86,7 @@ class EmployerCreatorShould : TestBase() {
     val actualEmployer = employerCaptor.firstValue
 
     assertThat(actualEmployer.createdAt).isEqualTo(expectedEmployer.createdAt)
+    assertThat(actualEmployer.modifiedAt).isEqualTo(expectedEmployer.modifiedAt)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerRetrieverShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/EmployerRetrieverShould.kt
@@ -42,7 +42,6 @@ class EmployerRetrieverShould {
     description = "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
     sector = "RETAIL",
     status = "SILVER",
-    createdAt = fixedTime,
   )
 
   private val sainsburysEmployer = Employer(
@@ -51,7 +50,6 @@ class EmployerRetrieverShould {
     description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
     sector = "RETAIL",
     status = "GOLD",
-    createdAt = fixedTime,
   )
 
   private val expectedEmployer = sainsburysEmployer

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/TestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/TestBase.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepos
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
-import java.time.Clock
 import java.time.LocalDate
 import java.time.Month.JULY
 
@@ -20,9 +19,6 @@ abstract class TestBase {
 
   @Mock
   protected lateinit var employerRepository: EmployerRepository
-
-  @Mock
-  protected lateinit var clock: Clock
 
   protected val amazonEmployer = Employer(
     id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/TestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/TestBase.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
 import java.time.Clock
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.Month.JULY
 
 @ExtendWith(MockitoExtension::class)
@@ -25,15 +24,12 @@ abstract class TestBase {
   @Mock
   protected lateinit var clock: Clock
 
-  protected val fixedTime = LocalDateTime.of(2024, JULY, 20, 22, 6)
-
   protected val amazonEmployer = Employer(
     id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),
     name = "Amazon",
     description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
     sector = "LOGISTICS",
     status = "KEY_PARTNER",
-    createdAt = fixedTime,
   )
 
   private val amazonForkliftOperatorJob = Job(


### PR DESCRIPTION
This PR
* Added audit field "modifiedAt" to entity "Employer"
* Enabled JPA Auditing for Employer; (replacing manual timestamping)
* Fixed broken tests (of Job, Employer) due to Employer changes above
* Added new test cases for Employer Repository (around the two auditing timestamp fields)
* Removed some unused properties/imports (tidy-up)
* The new audit field (Employer modifiedAt) is a breaking change to DB