### PR TITLE
[ESWE-1056] Schedule rds downtime

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,6 +4,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: jobs-board-api-dev.hmpps.service.justice.gov.uk
 


### PR DESCRIPTION
As per the [MoJ’s “creating a database” guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/create.html#non-production), non-production databases must be stopped out of working hours.

Environment: **DEV**