### PR TITLE
[ESWE-1055] Schedule rds downtime

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: jobs-board-api-preprod.hmpps.service.justice.gov.uk
 


### PR DESCRIPTION
As per the [MoJ’s “creating a database” guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/relational-databases/create.html#non-production), non-production databases must be stopped out of working hours.

Environment: **PREPROD**