### PR TITLE
[ESWE-1059] Fixes HMPPS preproduction oauth token path

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
             jwk-set-uri: ${api.base.url.oauth}/.well-known/jwks.json
         provider:
           hmpps-auth:
-            token-uri: ${api.base.url.oauth}//auth/oauth/token
+            token-uri: ${api.base.url.oauth}/oauth/token
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"


### PR DESCRIPTION
This PR fixes the path defined for the `token-uri` configured for preproduction and production.