### PR TITLE
[ESWE-1051] Rename ExpressionOfInterestId for code sharing

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ExpressionOfInterestRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ExpressionOfInterestRepositoryShould.kt
@@ -23,9 +23,9 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterest
-import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobPrisonerId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
 import java.time.Instant
@@ -302,5 +302,5 @@ class ExpressionOfInterestRepositoryShould {
   }
 
   private fun makeExpressionOfInterest(job: Job, prisonNumber: String): ExpressionOfInterest =
-    ExpressionOfInterest(id = ExpressionOfInterestId(job.id, prisonNumber), job = job)
+    ExpressionOfInterest(id = JobPrisonerId(job.id, prisonNumber), job = job)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestCreator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestCreator.kt
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterest
-import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestRepository
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobPrisonerId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
 
 @Service
@@ -20,7 +20,7 @@ class ExpressionOfInterestCreator(
       .orElseThrow { IllegalArgumentException("Job not found: jobId=${request.jobId}") }
 
     val expressionOfInterest = ExpressionOfInterest(
-      id = ExpressionOfInterestId(job.id, request.prisonNumber),
+      id = JobPrisonerId(job.id, request.prisonNumber),
       job = job,
     )
 
@@ -31,6 +31,6 @@ class ExpressionOfInterestCreator(
     if (jobRepository.findById(EntityId(jobId)).isEmpty) {
       throw IllegalArgumentException("Job not found: jobId=$jobId")
     }
-    return expressionOfInterestRepository.existsById(ExpressionOfInterestId(EntityId(jobId), prisonNumber))
+    return expressionOfInterestRepository.existsById(JobPrisonerId(EntityId(jobId), prisonNumber))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestDeleter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestDeleter.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
-import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestRepository
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobPrisonerId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
 
 @Service
@@ -16,7 +16,7 @@ class ExpressionOfInterestDeleter(
   @Transactional
   fun delete(request: DeleteExpressionOfInterestRequest) =
     expressionOfInterestRepository.deleteById(
-      ExpressionOfInterestId(
+      JobPrisonerId(
         jobId = EntityId(request.jobId),
         prisonNumber = request.prisonNumber,
       ),
@@ -26,6 +26,6 @@ class ExpressionOfInterestDeleter(
     if (jobRepository.findById(EntityId(jobId)).isEmpty) {
       throw IllegalArgumentException("Job not found: jobId=$jobId")
     }
-    return expressionOfInterestRepository.existsById(ExpressionOfInterestId(EntityId(jobId), prisonNumber))
+    return expressionOfInterestRepository.existsById(JobPrisonerId(EntityId(jobId), prisonNumber))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ExpressionOfInterest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ExpressionOfInterest.kt
@@ -18,7 +18,7 @@ import java.time.Instant
 data class ExpressionOfInterest(
 
   @EmbeddedId
-  var id: ExpressionOfInterestId,
+  var id: JobPrisonerId,
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ExpressionOfInterestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ExpressionOfInterestRepository.kt
@@ -4,4 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ExpressionOfInterestRepository : JpaRepository<ExpressionOfInterest, ExpressionOfInterestId>
+interface ExpressionOfInterestRepository : JpaRepository<ExpressionOfInterest, JobPrisonerId>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobPrisonerId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobPrisonerId.kt
@@ -8,7 +8,7 @@ import java.io.Serializable
 const val PRISON_NUMBER_MAX_LENGTH: Int = 7
 
 @Embeddable
-data class ExpressionOfInterestId(
+data class JobPrisonerId(
   @Column(name = "job_id")
   val jobId: EntityId,
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestCreatorShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestCreatorShould.kt
@@ -10,9 +10,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterest
-import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobPrisonerId
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -146,8 +146,8 @@ class ExpressionOfInterestCreatorShould : TestBase() {
   }
 
   private fun makeExpressionOfInterestId(jobId: String, prisonNumber: String) =
-    ExpressionOfInterestId(EntityId(jobId), prisonNumber)
+    JobPrisonerId(EntityId(jobId), prisonNumber)
 
   private fun makeExpressionOfInterest(job: Job, prisonNumber: String): ExpressionOfInterest =
-    ExpressionOfInterest(id = ExpressionOfInterestId(job.id, prisonNumber), job = job)
+    ExpressionOfInterest(id = JobPrisonerId(job.id, prisonNumber), job = job)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestDeleterShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/ExpressionOfInterestDeleterShould.kt
@@ -9,9 +9,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterest
-import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobPrisonerId
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -133,8 +133,8 @@ class ExpressionOfInterestDeleterShould : TestBase() {
   }
 
   private fun makeExpressionOfInterestId(jobId: String, prisonNumber: String) =
-    ExpressionOfInterestId(EntityId(jobId), prisonNumber)
+    JobPrisonerId(EntityId(jobId), prisonNumber)
 
   private fun makeExpressionOfInterest(job: Job, prisonNumber: String): ExpressionOfInterest =
-    ExpressionOfInterest(id = ExpressionOfInterestId(job.id, prisonNumber), job = job)
+    ExpressionOfInterest(id = JobPrisonerId(job.id, prisonNumber), job = job)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobPrisonerIdShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobPrisonerIdShould.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class ExpressionOfInterestIdShould {
+class JobPrisonerIdShould {
   // This is UUID v4, not yet v7
   private val validJobId = "b67d9daf-fb7e-462b-9baf-dd4c8f62a3a7"
 
@@ -61,6 +61,6 @@ class ExpressionOfInterestIdShould {
     assertEquals("prisonNumber cannot be empty", exception.message)
   }
 
-  private fun makeId(jobId: String, prisonNumber: String): ExpressionOfInterestId =
-    ExpressionOfInterestId(EntityId(jobId), prisonNumber)
+  private fun makeId(jobId: String, prisonNumber: String): JobPrisonerId =
+    JobPrisonerId(EntityId(jobId), prisonNumber)
 }


### PR DESCRIPTION
Refactoring for common codes
ExpressionOfInterestId identity class has been renamed to JobPrisonerId to denote an identity of job-prisoner relation. 

Existing usage: Expression of Interest
Next usage: Job Archive