### PR TITLE
[ESWE-865] Empty candidate matching jobs list

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
     environment:
-      - SPRING_PROFILES_ACTIVE=developer
+      - SPRING_PROFILES_ACTIVE=dev
       - SERVER_PORT=8080
       - DATABASE_ENDPOINT=job-board-db
       - DATABASE_NAME=job-board

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchedJobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchedJobsGetShould.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
+
+import org.junit.jupiter.api.Test
+
+class MatchedJobsGetShould : MatchedJobsTestCase() {
+  @Test
+  fun `retrieve a default paginated empty candidate matching Jobs list`() {
+    assertGetMatchedJobsIsOK(
+      expectedResponse = expectedResponseListOf(),
+    )
+  }
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchedJobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchedJobsTestCase.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
+
+import org.springframework.http.HttpStatus.OK
+
+const val MATCHING_CANDIDATE_ENDPOINT = "${JOBS_ENDPOINT}/matching-candidate"
+
+abstract class MatchedJobsTestCase : JobsTestCase() {
+
+  protected fun assertGetMatchedJobsIsOK(expectedResponse: String) {
+    assertResponse(
+      url = MATCHING_CANDIDATE_ENDPOINT,
+      expectedStatus = OK,
+      expectedResponse = expectedResponse,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -58,4 +58,13 @@ class JobsGet(private val jobRetriever: JobRetriever) {
     val response = jobList.map { GetJobsResponse.from(it) }
     return ResponseEntity.ok(response)
   }
+
+  @PreAuthorize("hasRole('ROLE_EDUCATION_WORK_PLAN_VIEW') or hasRole('ROLE_EDUCATION_WORK_PLAN_EDIT')")
+  @GetMapping("/matching-candidate")
+  fun retrieveAll(): ResponseEntity<Page<String>> {
+    val page = 0
+    val size = 10
+    val pageable: Pageable = PageRequest.of(page, size)
+    return ResponseEntity.ok(Page.empty(pageable))
+  }
 }


### PR DESCRIPTION
This PR sets the minimum infrastructure to enable the new `jobs/matching-candidate` endpoint.
For now, it will return an empty paginated list, allowing initial wiring testing in Dev and Preprod environments.