### PR TITLE
[ESWE-858] fix HTTP error codes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/HmppsJobsBoardApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/HmppsJobsBoardApiExceptionHandler.kt
@@ -4,10 +4,14 @@ import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
 class HmppsJobsBoardApiExceptionHandler {
@@ -24,6 +28,28 @@ class HmppsJobsBoardApiExceptionHandler {
         ),
       )
   }
+
+  @ExceptionHandler(NoResourceFoundException::class)
+  fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(NOT_FOUND)
+    .body(
+      ErrorResponse(
+        status = NOT_FOUND,
+        userMessage = "No resource found failure: ${e.message}",
+        developerMessage = e.message,
+      ),
+    ).also { log.info("No resource found exception: {}", e.message) }
+
+  @ExceptionHandler(AccessDeniedException::class)
+  fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(FORBIDDEN)
+    .body(
+      ErrorResponse(
+        status = FORBIDDEN,
+        userMessage = "Forbidden: ${e.message}",
+        developerMessage = e.message,
+      ),
+    ).also { log.debug("Forbidden (403) returned: {}", e.message) }
 
   @ExceptionHandler(IllegalArgumentException::class)
   fun handleIllegalArgumentException(e: Exception): ResponseEntity<ErrorResponse> {


### PR DESCRIPTION
Add back default handlers for 404 and 403 errors
from kotlin template (500-error were thrown if without these)