### PR TITLE
[ESWE-865] Matching candidates list provides job ID

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -38,6 +39,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.result.isEqualTo
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EMPLOYERS_ENDPOINT
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.EXPRESSIONS_OF_INTEREST_PATH_PREFIX
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JOBS_ENDPOINT
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
@@ -201,6 +204,45 @@ abstract class ApplicationTestCase {
     )
     return employerId
   }
+
+  protected fun assertAddExpressionOfInterest(
+    jobId: String? = null,
+    prisonNumber: String? = null,
+    expectedStatus: HttpStatus = CREATED,
+    matchRedirectedUrl: Boolean = false,
+  ): Array<String> = assertEditExpressionOfInterest(
+    jobId = jobId,
+    prisonNumber = prisonNumber,
+    expectedStatus = expectedStatus,
+    expectedHttpVerb = PUT,
+    matchRedirectedUrl = matchRedirectedUrl,
+  )
+
+  protected fun assertEditExpressionOfInterest(
+    jobId: String? = null,
+    prisonNumber: String? = null,
+    expectedStatus: HttpStatus,
+    expectedHttpVerb: HttpMethod,
+    expectedResponse: String? = null,
+    matchRedirectedUrl: Boolean = false,
+  ): Array<String> {
+    val finalJobId = jobId ?: randomUUID()
+    val finalPrisonNumber = prisonNumber ?: randomPrisonNumber()
+    val url = "$JOBS_ENDPOINT/$finalJobId/$EXPRESSIONS_OF_INTEREST_PATH_PREFIX/$finalPrisonNumber"
+    assertRequestWithoutBody(
+      url = url,
+      expectedStatus = expectedStatus,
+      expectedHttpVerb = expectedHttpVerb,
+      expectedResponse = expectedResponse,
+      expectedRedirectUrlPattern = if (matchRedirectedUrl) "http*://*$url" else null,
+    )
+    return arrayOf(finalJobId, finalPrisonNumber)
+  }
+
+  protected fun randomUUID(): String = UUID.randomUUID().toString()
+
+  protected fun randomPrisonNumber(): String =
+    randomAlphabets(1) + randomDigits(4) + randomAlphabets(2)
 
   protected fun assertRequestWithBody(
     url: String,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedDeleteShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedDeleteShould.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
 
 class ArchivedDeleteShould : ArchivedTestCase() {
-  val prisonNumber = "A1234BC"
 
   @Test
   fun `delete Archived, when it exists`() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
@@ -106,11 +106,6 @@ abstract class ArchivedTestCase : JobsTestCase() {
     return arrayOf(finalJobId, finalPrisonNumber)
   }
 
-  protected fun randomUUID(): String = UUID.randomUUID().toString()
-
-  protected fun randomPrisonNumber(): String =
-    randomAlphabets(1) + randomDigits(4) + randomAlphabets(2)
-
   protected fun obtainJobIdGivenAJobIsJustCreated(): String {
     assertAddEmployer(
       id = "bf392249-b360-4e3e-81a0-8497047987e8",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestDeleteShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestDeleteShould.kt
@@ -6,8 +6,6 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
 
 class ExpressionsOfInterestDeleteShould : ExpressionsOfInterestTestCase() {
-  val prisonNumber = "A1234BC"
-
   @Test
   fun `delete ExpressionOfInterest, when it exists`() {
     val ids = givenAJobIsCreatedWithExpressionOfInterest()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
@@ -18,19 +18,6 @@ abstract class ExpressionsOfInterestTestCase : JobsTestCase() {
   protected val nonExistentPrisonNumber = "Z9999AA"
   protected val invalidUUID = "00000000-0000-0000-0000-00000"
 
-  protected fun assertAddExpressionOfInterest(
-    jobId: String? = null,
-    prisonNumber: String? = null,
-    expectedStatus: HttpStatus = CREATED,
-    matchRedirectedUrl: Boolean = false,
-  ): Array<String> = assertEditExpressionOfInterest(
-    jobId = jobId,
-    prisonNumber = prisonNumber,
-    expectedStatus = expectedStatus,
-    expectedHttpVerb = PUT,
-    matchRedirectedUrl = matchRedirectedUrl,
-  )
-
   protected fun assertAddExpressionOfInterestThrowsValidationOrIllegalArgumentError(
     jobId: String? = null,
     prisonNumber: String? = null,
@@ -84,32 +71,6 @@ abstract class ExpressionsOfInterestTestCase : JobsTestCase() {
     expectedHttpVerb = expectedHttpVerb,
     expectedResponse = expectedResponse,
   )
-
-  private fun assertEditExpressionOfInterest(
-    jobId: String? = null,
-    prisonNumber: String? = null,
-    expectedStatus: HttpStatus,
-    expectedHttpVerb: HttpMethod,
-    expectedResponse: String? = null,
-    matchRedirectedUrl: Boolean = false,
-  ): Array<String> {
-    val finalJobId = jobId ?: randomUUID()
-    val finalPrisonNumber = prisonNumber ?: randomPrisonNumber()
-    val url = "$JOBS_ENDPOINT/$finalJobId/$EXPRESSIONS_OF_INTEREST_PATH_PREFIX/$finalPrisonNumber"
-    assertRequestWithoutBody(
-      url = url,
-      expectedStatus = expectedStatus,
-      expectedHttpVerb = expectedHttpVerb,
-      expectedResponse = expectedResponse,
-      expectedRedirectUrlPattern = if (matchRedirectedUrl) "http*://*$url" else null,
-    )
-    return arrayOf(finalJobId, finalPrisonNumber)
-  }
-
-  protected fun randomUUID(): String = UUID.randomUUID().toString()
-
-  protected fun randomPrisonNumber(): String =
-    randomAlphabets(1) + randomDigits(4) + randomAlphabets(2)
 
   protected fun obtainJobIdGivenAJobIsJustCreated(): String {
     assertAddEmployer(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -10,13 +10,13 @@ import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
 import java.time.Instant
-import java.util.Optional
-import java.util.UUID.randomUUID
+import java.util.*
 
 const val JOBS_ENDPOINT = "/jobs"
 
 class JobsTestCase : ApplicationTestCase() {
   val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
+  val prisonNumber = "A1234BC"
 
   @BeforeEach
   override fun setup() {
@@ -158,6 +158,8 @@ class JobsTestCase : ApplicationTestCase() {
       id = "6fdf2bf4-cfe6-419c-bab2-b3673adbb393",
       body = abcConstructionJobBody,
     )
+
+    assertAddExpressionOfInterest("6fdf2bf4-cfe6-419c-bab2-b3673adbb393", prisonNumber)
   }
 
   protected val abcConstructionJobBody: String = newJobBody(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -26,11 +26,11 @@ class JobsTestCase : ApplicationTestCase() {
 
   protected fun assertAddJobIsCreated(
     body: String,
-    jobId: String? = null,
+    id: String? = null,
   ): String {
     return assertAddJob(
       body = body,
-      jobId = jobId,
+      id = id,
       expectedStatus = CREATED,
     )
   }
@@ -40,7 +40,7 @@ class JobsTestCase : ApplicationTestCase() {
     body: String,
   ): String {
     return assertAddJob(
-      jobId = jobId,
+      id = jobId,
       body = body,
       expectedStatus = OK,
     )
@@ -52,7 +52,7 @@ class JobsTestCase : ApplicationTestCase() {
     expectedResponse: String,
   ) {
     assertAddJob(
-      jobId = jobId,
+      id = jobId,
       body = body,
       expectedStatus = BAD_REQUEST,
       expectedResponse = expectedResponse,
@@ -60,12 +60,12 @@ class JobsTestCase : ApplicationTestCase() {
   }
 
   private fun assertAddJob(
-    jobId: String? = null,
+    id: String? = null,
     body: String,
     expectedStatus: HttpStatus,
     expectedResponse: String? = null,
   ): String {
-    val finalJobId = jobId ?: randomUUID().toString()
+    val finalJobId = id ?: randomUUID().toString()
     assertRequestWithBody(
       url = "$JOBS_ENDPOINT/$finalJobId",
       body = body,
@@ -145,14 +145,17 @@ class JobsTestCase : ApplicationTestCase() {
     )
 
     assertAddJobIsCreated(
+      id = "04295747-e60d-4e51-9716-e721a63bdd06",
       body = tescoWarehouseHandlerJobBody,
     )
 
     assertAddJobIsCreated(
+      id = "d3035924-f9fe-426f-b253-f7c8225167ae",
       body = amazonForkliftOperatorJobBody,
     )
 
     assertAddJobIsCreated(
+      id = "6fdf2bf4-cfe6-419c-bab2-b3673adbb393",
       body = abcConstructionJobBody,
     )
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateTestCase.kt
@@ -47,6 +47,7 @@ abstract class MatchingCandidateTestCase : JobsTestCase() {
   }
 
   protected fun amazonForkliftOperatorMatchingCandidateJobItemListResponse(createdAt: Instant): String = newMatchingCandidateJobItemListResponse(
+    id = "d3035924-f9fe-426f-b253-f7c8225167ae",
     jobTitle = "Forklift operator",
     employerName = "Amazon",
     sector = "RETAIL",
@@ -58,6 +59,7 @@ abstract class MatchingCandidateTestCase : JobsTestCase() {
   )
 
   protected fun tescoWarehouseHandlerMatchingCandidateJobItemListResponse(createdAt: Instant): String = newMatchingCandidateJobItemListResponse(
+    id = "04295747-e60d-4e51-9716-e721a63bdd06",
     jobTitle = "Warehouse handler",
     employerName = "Tesco",
     sector = "WAREHOUSING",
@@ -69,6 +71,7 @@ abstract class MatchingCandidateTestCase : JobsTestCase() {
   )
 
   protected fun abcConstructionMatchingCandidateJobItemListResponse(createdAt: Instant): String = newMatchingCandidateJobItemListResponse(
+    id = "6fdf2bf4-cfe6-419c-bab2-b3673adbb393",
     jobTitle = "Apprentice plasterer",
     employerName = "ABC Construction",
     sector = "CONSTRUCTION",
@@ -80,6 +83,7 @@ abstract class MatchingCandidateTestCase : JobsTestCase() {
   )
 
   private fun newMatchingCandidateJobItemListResponse(
+    id: String,
     jobTitle: String,
     employerName: String,
     sector: String,
@@ -91,6 +95,7 @@ abstract class MatchingCandidateTestCase : JobsTestCase() {
   ): String {
     return """
         {
+          "id": "$id",
           "jobTitle": "$jobTitle",
           "employerName": "$employerName",
           "sector": "$sector",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetMatchingCandidateJobsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetMatchingCandidateJobsResponse.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 
 data class GetMatchingCandidateJobsResponse(
+  val id: String,
   val jobTitle: String,
   val employerName: String,
   val sector: String,
@@ -15,6 +16,7 @@ data class GetMatchingCandidateJobsResponse(
   companion object {
     fun from(job: Job): GetMatchingCandidateJobsResponse {
       return GetMatchingCandidateJobsResponse(
+        id = job.id.toString(),
         jobTitle = job.title,
         employerName = job.employer.name,
         sector = job.sector,


### PR DESCRIPTION
This PR:
- Adds the missing Job ID on each list item.
- Makes 'expression of interest' test assertion functions access wider so it can be used to set specific scenarios of matching candidates.