### PR TITLE
[ESWE-865] Extracts Employer test objects

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -145,50 +145,6 @@ abstract class ApplicationTestCase {
 
   private fun httpHeaders(): HttpHeaders = this.setAuthorisation(roles = listOf("ROLE_EDUCATION_WORK_PLAN_EDIT"))
 
-  protected fun newEmployerBody(name: String, description: String, sector: String, status: String): String = """
-        {
-          "name": "$name",
-          "description": "$description",
-          "sector": "$sector",
-          "status": "$status"
-        }
-  """.trimIndent()
-
-  val tescoBody: String = newEmployerBody(
-    name = "Tesco",
-    description = "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
-    sector = "RETAIL",
-    status = "SILVER",
-  )
-
-  val tescoLogisticsBody: String = newEmployerBody(
-    name = "Tesco",
-    description = "This is another Tesco employer that provides logistic services.",
-    sector = "LOGISTICS",
-    status = "GOLD",
-  )
-
-  val sainsburysBody: String = newEmployerBody(
-    name = "Sainsbury's",
-    description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century.",
-    sector = "RETAIL",
-    status = "GOLD",
-  )
-
-  val amazonBody: String = newEmployerBody(
-    name = "Amazon",
-    description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
-    sector = "LOGISTICS",
-    status = "KEY_PARTNER",
-  )
-
-  val abcConstructionBody: String = newEmployerBody(
-    name = "ABC Construction",
-    description = "This is a description",
-    sector = "CONSTRUCTION",
-    status = "SILVER",
-  )
-
   protected fun assertAddEmployer(
     id: String? = null,
     body: String,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -38,7 +38,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirec
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.result.isEqualTo
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EMPLOYERS_ENDPOINT
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.ARCHIVED_PATH_PREFIX
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.EXPRESSIONS_OF_INTEREST_PATH_PREFIX
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JOBS_ENDPOINT
@@ -144,22 +143,6 @@ abstract class ApplicationTestCase {
   }
 
   private fun httpHeaders(): HttpHeaders = this.setAuthorisation(roles = listOf("ROLE_EDUCATION_WORK_PLAN_EDIT"))
-
-  protected fun assertAddEmployer(
-    id: String? = null,
-    body: String,
-    expectedStatus: HttpStatus,
-    expectedResponse: String? = null,
-  ): String {
-    val employerId = id ?: randomUUID().toString()
-    assertRequestWithBody(
-      url = "$EMPLOYERS_ENDPOINT/$employerId",
-      body = body,
-      expectedStatus = expectedStatus,
-      expectedResponse = expectedResponse,
-    )
-    return employerId
-  }
 
   protected fun assertAddExpressionOfInterest(
     jobId: String? = null,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburysBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoLogisticsBody
 
 class EmployersGetShould : EmployerTestCase() {
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.responseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburys
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoLogistics
@@ -14,7 +14,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       employerId = employerId,
-      expectedResponse = tesco.requestBody,
+      expectedResponse = tesco.responseBody,
     )
   }
 
@@ -31,7 +31,7 @@ class EmployersGetShould : EmployerTestCase() {
     assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployerIsOK(
-      expectedResponse = expectedResponseListOf(tesco.requestBody, sainsburys.requestBody),
+      expectedResponse = expectedResponseListOf(tesco.responseBody, sainsburys.responseBody),
     )
   }
 
@@ -42,7 +42,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     this.assertGetEmployerIsOK(
       parameters = "page=1&size=1",
-      expectedResponse = expectedResponseListOf(size = 1, page = 1, totalElements = 2, tesco.requestBody),
+      expectedResponse = expectedResponseListOf(size = 1, page = 1, totalElements = 2, tesco.responseBody),
     )
   }
 
@@ -53,7 +53,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       parameters = "name=tesco",
-      expectedResponse = expectedResponseListOf(tesco.requestBody),
+      expectedResponse = expectedResponseListOf(tesco.responseBody),
     )
   }
 
@@ -64,7 +64,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       parameters = "name=tes",
-      expectedResponse = expectedResponseListOf(tesco.requestBody),
+      expectedResponse = expectedResponseListOf(tesco.responseBody),
     )
   }
 
@@ -75,7 +75,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       parameters = "sector=logistics",
-      expectedResponse = expectedResponseListOf(amazon.requestBody),
+      expectedResponse = expectedResponseListOf(amazon.responseBody),
     )
   }
 
@@ -88,7 +88,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       parameters = "name=Tesco&sector=LOGISTICS",
-      expectedResponse = expectedResponseListOf(tescoLogistics.requestBody),
+      expectedResponse = expectedResponseListOf(tescoLogistics.responseBody),
     )
   }
 
@@ -101,7 +101,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       parameters = "name=sAINS&sector=retail",
-      expectedResponse = expectedResponseListOf(sainsburys.requestBody),
+      expectedResponse = expectedResponseListOf(sainsburys.responseBody),
     )
   }
 
@@ -114,7 +114,7 @@ class EmployersGetShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       parameters = "name=Sainsbury's&sector=RETAIL&page=0&size=1",
-      expectedResponse = expectedResponseListOf(size = 1, page = 0, sainsburys.requestBody),
+      expectedResponse = expectedResponseListOf(size = 1, page = 0, sainsburys.responseBody),
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -1,19 +1,20 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburysBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoLogisticsBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburys
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoLogistics
 
 class EmployersGetShould : EmployerTestCase() {
   @Test
   fun `retrieve an existing Employer`() {
-    val employerId = assertAddEmployerIsCreated(body = tescoBody)
+    val employerId = assertAddEmployerIsCreated(body = tesco.requestBody)
 
     assertGetEmployerIsOK(
       employerId = employerId,
-      expectedResponse = tescoBody,
+      expectedResponse = tesco.requestBody,
     )
   }
 
@@ -26,101 +27,101 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployerIsOK(
-      expectedResponse = expectedResponseListOf(tescoBody, sainsburysBody),
+      expectedResponse = expectedResponseListOf(tesco.requestBody, sainsburys.requestBody),
     )
   }
 
   @Test
   fun `retrieve a custom paginated Employers list`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     this.assertGetEmployerIsOK(
       parameters = "page=1&size=1",
-      expectedResponse = expectedResponseListOf(size = 1, page = 1, totalElements = 2, tescoBody),
+      expectedResponse = expectedResponseListOf(size = 1, page = 1, totalElements = 2, tesco.requestBody),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list filtered by full name`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployerIsOK(
       parameters = "name=tesco",
-      expectedResponse = expectedResponseListOf(tescoBody),
+      expectedResponse = expectedResponseListOf(tesco.requestBody),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list filtered by incomplete name`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployerIsOK(
       parameters = "name=tes",
-      expectedResponse = expectedResponseListOf(tescoBody),
+      expectedResponse = expectedResponseListOf(tesco.requestBody),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list filtered by industry sector`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = amazonBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = amazon.requestBody)
 
     assertGetEmployerIsOK(
       parameters = "sector=logistics",
-      expectedResponse = expectedResponseListOf(amazonBody),
+      expectedResponse = expectedResponseListOf(amazon.requestBody),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list filtered by name AND sector`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = tescoLogisticsBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
-    assertAddEmployerIsCreated(body = amazonBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = tescoLogistics.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(body = amazon.requestBody)
 
     assertGetEmployerIsOK(
       parameters = "name=Tesco&sector=LOGISTICS",
-      expectedResponse = expectedResponseListOf(tescoLogisticsBody),
+      expectedResponse = expectedResponseListOf(tescoLogistics.requestBody),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list filtered by incomplete name AND sector`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = tescoLogisticsBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
-    assertAddEmployerIsCreated(body = amazonBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = tescoLogistics.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(body = amazon.requestBody)
 
     assertGetEmployerIsOK(
       parameters = "name=sAINS&sector=retail",
-      expectedResponse = expectedResponseListOf(sainsburysBody),
+      expectedResponse = expectedResponseListOf(sainsburys.requestBody),
     )
   }
 
   @Test
   fun `retrieve a custom paginated Employers list filtered by name AND sector`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = tescoLogisticsBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
-    assertAddEmployerIsCreated(body = amazonBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = tescoLogistics.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(body = amazon.requestBody)
 
     assertGetEmployerIsOK(
       parameters = "name=Sainsbury's&sector=RETAIL&page=0&size=1",
-      expectedResponse = expectedResponseListOf(size = 1, page = 0, sainsburysBody),
+      expectedResponse = expectedResponseListOf(size = 1, page = 0, sainsburys.requestBody),
     )
   }
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in ascending order, by default`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployersIsOKAndSortedByName(
       expectedNamesSorted = listOf("Sainsbury's", "Tesco"),
@@ -129,8 +130,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in ascending order`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployersIsOKAndSortedByName(
       parameters = "sortBy=name&sortOrder=asc",
@@ -140,8 +141,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in descending order`() {
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployersIsOKAndSortedByName(
       parameters = "sortBy=name&sortOrder=desc",
@@ -153,8 +154,8 @@ class EmployersGetShould : EmployerTestCase() {
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order, by default`() {
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt",
@@ -167,8 +168,8 @@ class EmployersGetShould : EmployerTestCase() {
     val sortingOrder = "asc"
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=$sortingOrder",
@@ -181,8 +182,8 @@ class EmployersGetShould : EmployerTestCase() {
     val sortingOrder = "desc"
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
-    assertAddEmployerIsCreated(body = tescoBody)
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = tesco.requestBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=$sortingOrder",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.Employers
 class EmployersGetShould : EmployerTestCase() {
   @Test
   fun `retrieve an existing Employer`() {
-    val employerId = assertAddEmployerIsCreated(body = tesco.requestBody)
+    val employerId = assertAddEmployerIsCreated(employer = tesco)
 
     assertGetEmployerIsOK(
       employerId = employerId,
@@ -27,8 +27,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployerIsOK(
       expectedResponse = expectedResponseListOf(tesco.requestBody, sainsburys.requestBody),
@@ -37,8 +37,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a custom paginated Employers list`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     this.assertGetEmployerIsOK(
       parameters = "page=1&size=1",
@@ -48,8 +48,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by full name`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployerIsOK(
       parameters = "name=tesco",
@@ -59,8 +59,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by incomplete name`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployerIsOK(
       parameters = "name=tes",
@@ -70,8 +70,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by industry sector`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = amazon.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = amazon)
 
     assertGetEmployerIsOK(
       parameters = "sector=logistics",
@@ -81,10 +81,10 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by name AND sector`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = tescoLogistics.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
-    assertAddEmployerIsCreated(body = amazon.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = tescoLogistics)
+    assertAddEmployerIsCreated(employer = sainsburys)
+    assertAddEmployerIsCreated(employer = amazon)
 
     assertGetEmployerIsOK(
       parameters = "name=Tesco&sector=LOGISTICS",
@@ -94,10 +94,10 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by incomplete name AND sector`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = tescoLogistics.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
-    assertAddEmployerIsCreated(body = amazon.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = tescoLogistics)
+    assertAddEmployerIsCreated(employer = sainsburys)
+    assertAddEmployerIsCreated(employer = amazon)
 
     assertGetEmployerIsOK(
       parameters = "name=sAINS&sector=retail",
@@ -107,10 +107,10 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a custom paginated Employers list filtered by name AND sector`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = tescoLogistics.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
-    assertAddEmployerIsCreated(body = amazon.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = tescoLogistics)
+    assertAddEmployerIsCreated(employer = sainsburys)
+    assertAddEmployerIsCreated(employer = amazon)
 
     assertGetEmployerIsOK(
       parameters = "name=Sainsbury's&sector=RETAIL&page=0&size=1",
@@ -120,8 +120,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in ascending order, by default`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployersIsOKAndSortedByName(
       expectedNamesSorted = listOf("Sainsbury's", "Tesco"),
@@ -130,8 +130,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in ascending order`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployersIsOKAndSortedByName(
       parameters = "sortBy=name&sortOrder=asc",
@@ -141,8 +141,8 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in descending order`() {
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployersIsOKAndSortedByName(
       parameters = "sortBy=name&sortOrder=desc",
@@ -154,8 +154,8 @@ class EmployersGetShould : EmployerTestCase() {
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order, by default`() {
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt",
@@ -168,8 +168,8 @@ class EmployersGetShould : EmployerTestCase() {
     val sortingOrder = "asc"
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=$sortingOrder",
@@ -182,8 +182,8 @@ class EmployersGetShould : EmployerTestCase() {
     val sortingOrder = "desc"
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
 
-    assertAddEmployerIsCreated(body = tesco.requestBody)
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = sainsburys)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=$sortingOrder",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
@@ -4,15 +4,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 object EmployersMother {
-  private fun employerBody(name: String, description: String, sector: String, status: String): String = """
-        {
-          "name": "$name",
-          "description": "$description",
-          "sector": "$sector",
-          "status": "$status"
-        }
-  """.trimIndent()
-
   val tesco = Employer(
     id = EntityId("89de6c84-3372-4546-bbc1-9d1dc9ceb354"),
     name = "Tesco",
@@ -53,5 +44,34 @@ object EmployersMother {
     status = "SILVER",
   )
 
-  val Employer.requestBody: String get() = employerBody(name, description, sector, status)
+  val Employer.requestBody: String get() = employerRequestBody(name, description, sector, status)
+
+  val Employer.responseBody: String get() = employerResponseBody(id, name, description, sector, status)
+
+  private fun employerRequestBody(name: String, description: String, sector: String, status: String): String {
+    return employerBody(name, description, sector, status)
+  }
+
+  private fun employerResponseBody(id: EntityId, name: String, description: String, sector: String, status: String): String {
+    return employerBody(name, description, sector, status, id.id)
+  }
+
+  private fun employerBody(
+    name: String,
+    description: String,
+    sector: String,
+    status: String,
+    id: String? = null,
+  ): String {
+    val idField = id?.let { "\"id\": \"$it\"," } ?: ""
+    return """
+        {
+          $idField
+          "name": "$name",
+          "description": "$description",
+          "sector": "$sector",
+          "status": "$status"
+        }
+    """.trimIndent()
+  }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
+import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
+import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
+import java.util.*
+
 object EmployersMother {
-  fun newEmployerBody(name: String, description: String, sector: String, status: String): String = """
+  private fun employerBody(name: String, description: String, sector: String, status: String): String = """
         {
           "name": "$name",
           "description": "$description",
@@ -10,38 +14,45 @@ object EmployersMother {
         }
   """.trimIndent()
 
-  val tescoBody: String = newEmployerBody(
+  val tesco = Employer(
+    id = EntityId(UUID.randomUUID().toString()),
     name = "Tesco",
     description = "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
     sector = "RETAIL",
     status = "SILVER",
   )
 
-  val tescoLogisticsBody: String = newEmployerBody(
+  val tescoLogistics = Employer(
+    id = EntityId(UUID.randomUUID().toString()),
     name = "Tesco",
     description = "This is another Tesco employer that provides logistic services.",
     sector = "LOGISTICS",
     status = "GOLD",
   )
 
-  val sainsburysBody: String = newEmployerBody(
+  val sainsburys = Employer(
+    id = EntityId(UUID.randomUUID().toString()),
     name = "Sainsbury's",
     description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century.",
     sector = "RETAIL",
     status = "GOLD",
   )
 
-  val amazonBody: String = newEmployerBody(
+  val amazon = Employer(
+    id = EntityId(UUID.randomUUID().toString()),
     name = "Amazon",
     description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
     sector = "LOGISTICS",
     status = "KEY_PARTNER",
   )
 
-  val abcConstructionBody: String = newEmployerBody(
+  val abcConstruction = Employer(
+    id = EntityId(UUID.randomUUID().toString()),
     name = "ABC Construction",
     description = "This is a description",
     sector = "CONSTRUCTION",
     status = "SILVER",
   )
+
+  val Employer.requestBody: String get() = employerBody(name, description, sector, status)
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
-import java.util.*
 
 object EmployersMother {
   private fun employerBody(name: String, description: String, sector: String, status: String): String = """
@@ -15,7 +14,7 @@ object EmployersMother {
   """.trimIndent()
 
   val tesco = Employer(
-    id = EntityId(UUID.randomUUID().toString()),
+    id = EntityId("89de6c84-3372-4546-bbc1-9d1dc9ceb354"),
     name = "Tesco",
     description = "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
     sector = "RETAIL",
@@ -23,7 +22,7 @@ object EmployersMother {
   )
 
   val tescoLogistics = Employer(
-    id = EntityId(UUID.randomUUID().toString()),
+    id = EntityId("2c8032bf-e583-4ae9-bcec-968a1c4881f9"),
     name = "Tesco",
     description = "This is another Tesco employer that provides logistic services.",
     sector = "LOGISTICS",
@@ -31,7 +30,7 @@ object EmployersMother {
   )
 
   val sainsburys = Employer(
-    id = EntityId(UUID.randomUUID().toString()),
+    id = EntityId("f4fbdbf3-823c-4877-aafc-35a7fa74a15a"),
     name = "Sainsbury's",
     description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century.",
     sector = "RETAIL",
@@ -39,7 +38,7 @@ object EmployersMother {
   )
 
   val amazon = Employer(
-    id = EntityId(UUID.randomUUID().toString()),
+    id = EntityId("bf392249-b360-4e3e-81a0-8497047987e8"),
     name = "Amazon",
     description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
     sector = "LOGISTICS",
@@ -47,7 +46,7 @@ object EmployersMother {
   )
 
   val abcConstruction = Employer(
-    id = EntityId(UUID.randomUUID().toString()),
+    id = EntityId("182e9a24-6edb-48a6-a84f-b7061f004a97"),
     name = "ABC Construction",
     description = "This is a description",
     sector = "CONSTRUCTION",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersMother.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
+
+object EmployersMother {
+  fun newEmployerBody(name: String, description: String, sector: String, status: String): String = """
+        {
+          "name": "$name",
+          "description": "$description",
+          "sector": "$sector",
+          "status": "$status"
+        }
+  """.trimIndent()
+
+  val tescoBody: String = newEmployerBody(
+    name = "Tesco",
+    description = "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
+    sector = "RETAIL",
+    status = "SILVER",
+  )
+
+  val tescoLogisticsBody: String = newEmployerBody(
+    name = "Tesco",
+    description = "This is another Tesco employer that provides logistic services.",
+    sector = "LOGISTICS",
+    status = "GOLD",
+  )
+
+  val sainsburysBody: String = newEmployerBody(
+    name = "Sainsbury's",
+    description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century.",
+    sector = "RETAIL",
+    status = "GOLD",
+  )
+
+  val amazonBody: String = newEmployerBody(
+    name = "Amazon",
+    description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
+    sector = "LOGISTICS",
+    status = "KEY_PARTNER",
+  )
+
+  val abcConstructionBody: String = newEmployerBody(
+    name = "ABC Construction",
+    description = "This is a description",
+    sector = "CONSTRUCTION",
+    status = "SILVER",
+  )
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.Employers
 class EmployersPutShould : EmployerTestCase() {
   @Test
   fun `create a valid Employer`() {
-    assertAddEmployerIsCreated(body = sainsburys.requestBody)
+    assertAddEmployerIsCreated(employer = sainsburys)
   }
 
   @Test
@@ -30,7 +30,7 @@ class EmployersPutShould : EmployerTestCase() {
 
   @Test
   fun `update an existing Employer`() {
-    val employerId = assertAddEmployerIsCreated(body = tesco.requestBody)
+    val employerId = assertAddEmployerIsCreated(employer = tesco)
 
     assertUpdateEmployerIsOk(
       employerId = employerId,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburysBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
 
 class EmployersPutShould : EmployerTestCase() {
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
@@ -1,20 +1,21 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburysBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburys
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
 
 class EmployersPutShould : EmployerTestCase() {
   @Test
   fun `create a valid Employer`() {
-    assertAddEmployerIsCreated(body = sainsburysBody)
+    assertAddEmployerIsCreated(body = sainsburys.requestBody)
   }
 
   @Test
   fun `not create an Employer with invalid UUID`() {
     assertAddEmployerThrowsValidationError(
       employerId = "invalid-uuid",
-      body = tescoBody,
+      body = tesco.requestBody,
       expectedResponse = """
         {
           "status":400,
@@ -29,16 +30,16 @@ class EmployersPutShould : EmployerTestCase() {
 
   @Test
   fun `update an existing Employer`() {
-    val employerId = assertAddEmployerIsCreated(body = tescoBody)
+    val employerId = assertAddEmployerIsCreated(body = tesco.requestBody)
 
     assertUpdateEmployerIsOk(
       employerId = employerId,
-      body = sainsburysBody,
+      body = sainsburys.requestBody,
     )
 
     assertGetEmployerIsOK(
       employerId = employerId,
-      expectedResponse = sainsburysBody,
+      expectedResponse = sainsburys.requestBody,
     )
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.responseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.sainsburys
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
 
@@ -30,7 +31,7 @@ class EmployersPutShould : EmployerTestCase() {
 
   @Test
   fun `update an existing Employer`() {
-    val employerId = assertAddEmployerIsCreated(employer = tesco)
+    val employerId = assertAddEmployerIsCreated(employer = sainsburys)
 
     assertUpdateEmployerIsOk(
       employerId = employerId,
@@ -39,7 +40,7 @@ class EmployersPutShould : EmployerTestCase() {
 
     assertGetEmployerIsOK(
       employerId = employerId,
-      expectedResponse = sainsburys.requestBody,
+      expectedResponse = sainsburys.responseBody,
     )
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import java.time.Instant
-import java.util.UUID.randomUUID
 
 const val EMPLOYERS_ENDPOINT = "/employers"
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
@@ -1,21 +1,26 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
 import java.time.Instant
+import java.util.UUID.randomUUID
 
 const val EMPLOYERS_ENDPOINT = "/employers"
 
 class EmployerTestCase : ApplicationTestCase() {
   val employerCreationTime = Instant.parse("2024-07-01T01:00:00Z")
 
-  protected fun assertAddEmployerIsCreated(
-    body: String,
+  fun assertAddEmployerIsCreated(
+    employer: Employer,
   ): String {
     return assertAddEmployer(
-      body = body,
+      id = employer.id.id,
+      body = employer.requestBody,
       expectedStatus = CREATED,
     )
   }
@@ -90,5 +95,21 @@ class EmployerTestCase : ApplicationTestCase() {
       expectedStatus = OK,
       expectedDateSortingOrder = expectedSortingOrder,
     )
+  }
+
+  private fun assertAddEmployer(
+    id: String? = null,
+    body: String,
+    expectedStatus: HttpStatus,
+    expectedResponse: String? = null,
+  ): String {
+    val employerId = id ?: randomUUID().toString()
+    assertRequestWithBody(
+      url = "$EMPLOYERS_ENDPOINT/$employerId",
+      body = body,
+      expectedStatus = expectedStatus,
+      expectedResponse = expectedResponse,
+    )
+    return employerId
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
 
 const val ARCHIVED_PATH_PREFIX = "archived"
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
@@ -5,11 +5,9 @@ import org.springframework.http.HttpMethod.DELETE
 import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
-import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 
 const val ARCHIVED_PATH_PREFIX = "archived"
 
@@ -74,11 +72,7 @@ abstract class ArchivedTestCase : JobsTestCase() {
   )
 
   protected fun obtainJobIdGivenAJobIsJustCreated(): String {
-    assertAddEmployer(
-      id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazon.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = amazon)
     assertAddJobIsCreated(body = amazonForkliftOperatorJobBody).also { jobId ->
       return jobId
     }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 
 const val ARCHIVED_PATH_PREFIX = "archived"
 
@@ -75,7 +76,7 @@ abstract class ArchivedTestCase : JobsTestCase() {
   protected fun obtainJobIdGivenAJobIsJustCreated(): String {
     assertAddEmployer(
       id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazonBody,
+      body = amazon.requestBody,
       expectedStatus = CREATED,
     )
     assertAddJobIsCreated(body = amazonForkliftOperatorJobBody).also { jobId ->

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 import java.util.*
 
 const val EXPRESSIONS_OF_INTEREST_PATH_PREFIX = "expressions-of-interest"
@@ -76,7 +77,7 @@ abstract class ExpressionsOfInterestTestCase : JobsTestCase() {
   protected fun obtainJobIdGivenAJobIsJustCreated(): String {
     assertAddEmployer(
       id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazonBody,
+      body = amazon.requestBody,
       expectedStatus = CREATED,
     )
     assertAddJobIsCreated(body = amazonForkliftOperatorJobBody).also { jobId ->

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
 import java.util.*
 
 const val EXPRESSIONS_OF_INTEREST_PATH_PREFIX = "expressions-of-interest"

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 import java.util.*
 
 const val EXPRESSIONS_OF_INTEREST_PATH_PREFIX = "expressions-of-interest"
@@ -75,11 +74,7 @@ abstract class ExpressionsOfInterestTestCase : JobsTestCase() {
   )
 
   protected fun obtainJobIdGivenAJobIsJustCreated(): String {
-    assertAddEmployer(
-      id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazon.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = amazon)
     assertAddJobIsCreated(body = amazonForkliftOperatorJobBody).also { jobId ->
       return jobId
     }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ExpressionsOfInterestTestCase.kt
@@ -5,7 +5,6 @@ import org.springframework.http.HttpMethod.DELETE
 import org.springframework.http.HttpMethod.PUT
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
-import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.NO_CONTENT
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -1,20 +1,14 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus.CREATED
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstruction
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
 
 class JobsGetShould : JobsTestCase() {
   @Test
   fun `retrieve an existing Job`() {
-    assertAddEmployer(
-      id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazon.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = amazon)
 
     val jobId = assertAddJobIsCreated(body = amazonForkliftOperatorJobBody)
 
@@ -26,11 +20,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `retrieve an existing Job with all optional fields empty`() {
-    assertAddEmployer(
-      id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-      body = abcConstruction.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = abcConstruction)
 
     val jobId = assertAddJobIsCreated(body = abcConstructionJobBody)
 
@@ -42,11 +32,7 @@ class JobsGetShould : JobsTestCase() {
 
   @Test
   fun `return null on empty optional fields`() {
-    assertAddEmployer(
-      id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
-      body = tesco.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = tesco)
 
     val jobId = assertAddJobIsCreated(body = tescoWarehouseHandlerJobBody)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -2,16 +2,17 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstructionBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstruction
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
 
 class JobsGetShould : JobsTestCase() {
   @Test
   fun `retrieve an existing Job`() {
     assertAddEmployer(
       id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazonBody,
+      body = amazon.requestBody,
       expectedStatus = CREATED,
     )
 
@@ -27,7 +28,7 @@ class JobsGetShould : JobsTestCase() {
   fun `retrieve an existing Job with all optional fields empty`() {
     assertAddEmployer(
       id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-      body = abcConstructionBody,
+      body = abcConstruction.requestBody,
       expectedStatus = CREATED,
     )
 
@@ -43,7 +44,7 @@ class JobsGetShould : JobsTestCase() {
   fun `return null on empty optional fields`() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
-      body = tescoBody,
+      body = tesco.requestBody,
       expectedStatus = CREATED,
     )
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstructionBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
 
 class JobsGetShould : JobsTestCase() {
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
@@ -2,8 +2,9 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstructionBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstruction
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 import java.util.*
 
 class JobsPutShould : JobsTestCase() {
@@ -11,7 +12,7 @@ class JobsPutShould : JobsTestCase() {
   fun `create a valid Job`() {
     assertAddEmployer(
       id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazonBody,
+      body = amazon.requestBody,
       expectedStatus = CREATED,
     )
     assertAddJobIsCreated(body = amazonForkliftOperatorJobBody)
@@ -21,7 +22,7 @@ class JobsPutShould : JobsTestCase() {
   fun `create a valid Job with empty optional attributes`() {
     assertAddEmployer(
       id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-      body = abcConstructionBody,
+      body = abcConstruction.requestBody,
       expectedStatus = CREATED,
     )
     assertAddJobIsCreated(body = abcConstructionJobBody)
@@ -49,7 +50,7 @@ class JobsPutShould : JobsTestCase() {
     val employerId = "bf392249-b360-4e3e-81a0-8497047987e8"
     assertAddEmployer(
       id = employerId,
-      body = amazonBody,
+      body = amazon.requestBody,
       expectedStatus = CREATED,
     )
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus.CREATED
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstructionBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
 import java.util.*
 
 class JobsPutShould : JobsTestCase() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsPutShould.kt
@@ -1,30 +1,19 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus.CREATED
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstruction
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
-import java.util.*
 
 class JobsPutShould : JobsTestCase() {
   @Test
   fun `create a valid Job`() {
-    assertAddEmployer(
-      id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazon.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = amazon)
     assertAddJobIsCreated(body = amazonForkliftOperatorJobBody)
   }
 
   @Test
   fun `create a valid Job with empty optional attributes`() {
-    assertAddEmployer(
-      id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-      body = abcConstruction.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = abcConstruction)
     assertAddJobIsCreated(body = abcConstructionJobBody)
   }
 
@@ -48,11 +37,7 @@ class JobsPutShould : JobsTestCase() {
   @Test
   fun `update an existing Job`() {
     val employerId = "bf392249-b360-4e3e-81a0-8497047987e8"
-    assertAddEmployer(
-      id = employerId,
-      body = amazon.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = amazon)
 
     val jobId = assertAddJobIsCreated(body = amazonForkliftOperatorJobBody)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -8,10 +8,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
-import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerTestCase
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstruction
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
 import java.time.Instant
 import java.util.*
@@ -20,6 +19,7 @@ const val JOBS_ENDPOINT = "/jobs"
 
 class JobsTestCase : EmployerTestCase() {
   val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
+  val prisonNumber = "A1234BC"
 
   @BeforeEach
   override fun setup() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -9,9 +9,10 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstructionBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstruction
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.requestBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tesco
 import java.time.Instant
 import java.util.*
 
@@ -131,19 +132,19 @@ class JobsTestCase : ApplicationTestCase() {
   protected fun givenThreeJobsAreCreated() {
     assertAddEmployer(
       id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
-      body = tescoBody,
+      body = tesco.requestBody,
       expectedStatus = CREATED,
     )
 
     assertAddEmployer(
       id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazonBody,
+      body = amazon.requestBody,
       expectedStatus = CREATED,
     )
 
     assertAddEmployer(
       id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-      body = abcConstructionBody,
+      body = abcConstruction.requestBody,
       expectedStatus = CREATED,
     )
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -18,9 +18,8 @@ import java.util.*
 
 const val JOBS_ENDPOINT = "/jobs"
 
-class JobsTestCase : ApplicationTestCase() {
+class JobsTestCase : EmployerTestCase() {
   val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
-  val prisonNumber = "A1234BC"
 
   @BeforeEach
   override fun setup() {
@@ -130,23 +129,9 @@ class JobsTestCase : ApplicationTestCase() {
   }
 
   protected fun givenThreeJobsAreCreated() {
-    assertAddEmployer(
-      id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
-      body = tesco.requestBody,
-      expectedStatus = CREATED,
-    )
-
-    assertAddEmployer(
-      id = "bf392249-b360-4e3e-81a0-8497047987e8",
-      body = amazon.requestBody,
-      expectedStatus = CREATED,
-    )
-
-    assertAddEmployer(
-      id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-      body = abcConstruction.requestBody,
-      expectedStatus = CREATED,
-    )
+    assertAddEmployerIsCreated(employer = tesco)
+    assertAddEmployerIsCreated(employer = amazon)
+    assertAddEmployerIsCreated(employer = abcConstruction)
 
     assertAddJobIsCreated(
       id = "04295747-e60d-4e51-9716-e721a63bdd06",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.ApplicationTestCase
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.abcConstructionBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.amazonBody
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployersMother.tescoBody
 import java.time.Instant
 import java.util.*
 


### PR DESCRIPTION
This PR comprises a small series of refactors on the testing Employers domain. The idea is to have the dummy Employer objects that we use and their representations, like the request body needed for creation or the response body that we expect to receive from the endpoint, in the same place.

Another goal is to start abstracting the language used in our Integration tests so they do not reveal unnecessary implementation details.