### PR TITLE
[ESWE-865] Enables multiple test Employer creation

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersGetShould.kt
@@ -27,8 +27,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployerIsOK(
       expectedResponse = expectedResponseListOf(tesco.responseBody, sainsburys.responseBody),
@@ -37,8 +36,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a custom paginated Employers list`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     this.assertGetEmployerIsOK(
       parameters = "page=1&size=1",
@@ -48,8 +46,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by full name`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployerIsOK(
       parameters = "name=tesco",
@@ -59,8 +56,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by incomplete name`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployerIsOK(
       parameters = "name=tes",
@@ -70,8 +66,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by industry sector`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = amazon)
+    givenEmployersAreCreated(tesco, amazon)
 
     assertGetEmployerIsOK(
       parameters = "sector=logistics",
@@ -81,10 +76,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by name AND sector`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = tescoLogistics)
-    assertAddEmployerIsCreated(employer = sainsburys)
-    assertAddEmployerIsCreated(employer = amazon)
+    givenEmployersAreCreated(tesco, tescoLogistics, sainsburys, amazon)
 
     assertGetEmployerIsOK(
       parameters = "name=Tesco&sector=LOGISTICS",
@@ -94,10 +86,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list filtered by incomplete name AND sector`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = tescoLogistics)
-    assertAddEmployerIsCreated(employer = sainsburys)
-    assertAddEmployerIsCreated(employer = amazon)
+    givenEmployersAreCreated(tesco, tescoLogistics, sainsburys, amazon)
 
     assertGetEmployerIsOK(
       parameters = "name=sAINS&sector=retail",
@@ -107,10 +96,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a custom paginated Employers list filtered by name AND sector`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = tescoLogistics)
-    assertAddEmployerIsCreated(employer = sainsburys)
-    assertAddEmployerIsCreated(employer = amazon)
+    givenEmployersAreCreated(tesco, tescoLogistics, sainsburys, amazon)
 
     assertGetEmployerIsOK(
       parameters = "name=Sainsbury's&sector=RETAIL&page=0&size=1",
@@ -120,8 +106,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in ascending order, by default`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployersIsOKAndSortedByName(
       expectedNamesSorted = listOf("Sainsbury's", "Tesco"),
@@ -130,8 +115,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in ascending order`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployersIsOKAndSortedByName(
       parameters = "sortBy=name&sortOrder=asc",
@@ -141,8 +125,7 @@ class EmployersGetShould : EmployerTestCase() {
 
   @Test
   fun `retrieve a default paginated Employers list sorted by name, in descending order`() {
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployersIsOKAndSortedByName(
       parameters = "sortBy=name&sortOrder=desc",
@@ -153,9 +136,7 @@ class EmployersGetShould : EmployerTestCase() {
   @Test
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order, by default`() {
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
-
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt",
@@ -167,9 +148,7 @@ class EmployersGetShould : EmployerTestCase() {
   fun `retrieve a default paginated Employers list sorted by creation date, in ascending order`() {
     val sortingOrder = "asc"
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
-
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=$sortingOrder",
@@ -181,9 +160,7 @@ class EmployersGetShould : EmployerTestCase() {
   fun `retrieve a default paginated Employers list sorted by creation date, in descending order`() {
     val sortingOrder = "desc"
     givenEmployersHaveIncreasingIncrementByDayCreationTimes()
-
-    assertAddEmployerIsCreated(employer = tesco)
-    assertAddEmployerIsCreated(employer = sainsburys)
+    givenEmployersAreCreated(tesco, sainsburys)
 
     assertGetEmployersIsOkAndSortedByDate(
       parameters = "sortBy=createdAt&sortOrder=$sortingOrder",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
@@ -111,4 +111,8 @@ class EmployerTestCase : ApplicationTestCase() {
     )
     return employerId
   }
+
+  protected fun givenEmployersAreCreated(vararg employers: Employer) {
+    employers.forEach { employer -> assertAddEmployerIsCreated(employer = employer) }
+  }
 }


### PR DESCRIPTION
This small PR refactors the Employer's tests so they can create multiple elements in just one command.