### PR TITLE
[ESWE-865] Job mother refactor list items

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/EmployerRepositoryShould.kt
@@ -18,11 +18,12 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.jobsboard.api.config.TestJpaConfig
-import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.sainsburys
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.employerCreationTime
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.employerModificationTime
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
-import java.time.Instant
 import java.util.*
 
 @DataJpaTest
@@ -39,22 +40,9 @@ class EmployerRepositoryShould {
   @Autowired
   lateinit var employerRepository: EmployerRepository
 
-  val employerCreationTime = Instant.parse("2024-07-01T01:00:00Z")
-  val employerModificationTime = Instant.parse("2024-07-01T02:00:00Z")
-
-  private lateinit var employer: Employer
-
   @BeforeEach
   fun setUp() {
     employerRepository.deleteAll()
-    employer =
-      Employer(
-        id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),
-        name = "Sainsbury's",
-        description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century",
-        sector = "sector",
-        status = "status",
-      )
     whenever(dateTimeProvider.now).thenReturn(Optional.of(employerCreationTime))
   }
 
@@ -74,16 +62,16 @@ class EmployerRepositoryShould {
 
   @Test
   fun `save an Employer`() {
-    employerRepository.save(employer)
+    employerRepository.save(sainsburys)
   }
 
   @Test
   fun `find an existing Employer`() {
-    employerRepository.save(employer)
+    employerRepository.save(sainsburys)
 
     assertEquals(
-      Optional.of(employer),
-      employer.id.let { employerRepository.findById(it) },
+      Optional.of(sainsburys),
+      sainsburys.id.let { employerRepository.findById(it) },
     )
   }
 
@@ -94,14 +82,14 @@ class EmployerRepositoryShould {
 
   @Test
   fun `set createdAt attribute when saving a new employer`() {
-    val savedEmployer = employerRepository.save(employer)
+    val savedEmployer = employerRepository.save(sainsburys)
 
     assertThat(savedEmployer.createdAt).isEqualTo(employerCreationTime)
   }
 
   @Test
   fun `not update createdAt attribute when updating an existing Employer`() {
-    val savedEmployer = employerRepository.save(employer)
+    val savedEmployer = employerRepository.save(sainsburys)
 
     whenever(dateTimeProvider.now).thenReturn(Optional.of(employerModificationTime))
     val updatedJEmployer = employerRepository.save(savedEmployer)
@@ -111,14 +99,14 @@ class EmployerRepositoryShould {
 
   @Test
   fun `set modifiedAt attribute with same value as createdAt when saving a new Employer`() {
-    val savedEmployer = employerRepository.save(employer)
+    val savedEmployer = employerRepository.save(sainsburys)
 
     assertThat(savedEmployer.modifiedAt).isEqualTo(employerCreationTime)
   }
 
   @Test
   fun `update modifiedAt attribute with current date and time when updating an existing Employer`() {
-    val savedEmployer = employerRepository.save(employer)
+    val savedEmployer = employerRepository.save(sainsburys)
 
     whenever(dateTimeProvider.now).thenReturn(Optional.of(employerModificationTime))
     val updatedEmployer = employerRepository.saveAndFlush(savedEmployer)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ExpressionOfInterestRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ExpressionOfInterestRepositoryShould.kt
@@ -19,18 +19,20 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.jobsboard.api.config.TestJpaConfig
-import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
-import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterest
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobPrisonerId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.VALID_PRISON_NUMBER
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.jobCreationTime
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.jobRegisterExpressionOfInterestTime
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.nonExistentJob
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
-import java.time.Instant
-import java.time.LocalDate
-import java.time.Month.JULY
+import java.time.temporal.ChronoUnit.DAYS
 import java.util.*
 
 @DataJpaTest
@@ -55,120 +57,6 @@ class ExpressionOfInterestRepositoryShould {
 
   @Autowired
   private lateinit var expressionOfInterestRepository: ExpressionOfInterestRepository
-
-  private val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
-  private val jobRegisterExpressionOfInterestTime = Instant.parse("2025-03-01T01:00:00Z")
-  private val jobReRegisterExpressionOfInterestTime = Instant.parse("2025-03-02T01:00:00Z")
-
-  private val expectedPrisonNumber = Holder.expectedPrisonNumber
-  private val amazonForkliftOperatorJob = Holder.amazonForkliftOperatorJob
-  private val amazonEmployer = Holder.amazonEmployer
-  private val nonExistentJob = Holder.nonExistentJob
-
-  private object Holder {
-    val amazonEmployer = Employer(
-      id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),
-      name = "Amazon",
-      description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
-      sector = "LOGISTICS",
-      status = "KEY_PARTNER",
-    )
-
-    val amazonForkliftOperatorJob = Job(
-      id = EntityId("fe5d5175-5a21-4cec-a30b-fd87a5f76ce7"),
-      title = "Forklift operator",
-      sector = "WAREHOUSING",
-      industrySector = "LOGISTICS",
-      numberOfVacancies = 2,
-      sourcePrimary = "PEL",
-      sourceSecondary = "",
-      charityName = "",
-      postcode = "LS12",
-      salaryFrom = 11.93f,
-      salaryTo = 15.90f,
-      salaryPeriod = "PER_HOUR",
-      additionalSalaryInformation = "",
-      isPayingAtLeastNationalMinimumWage = false,
-      workPattern = "FLEXIBLE_SHIFTS",
-      hoursPerWeek = "FULL_TIME",
-      contractType = "TEMPORARY",
-      baseLocation = "WORKPLACE",
-      essentialCriteria = "",
-      desirableCriteria = "",
-      description = """
-        What's on offer:
-  
-        - 5 days over 7, 05:30 to 15:30
-        - Paid weekly
-        - Immediate starts available
-        - Full training provided
-  
-        Your duties will include:
-  
-        - Manoeuvring forklifts safely in busy industrial environments
-        - Safely stacking and unstacking large quantities of goods onto shelves or pallets
-        - Moving goods from storage areas to loading areas for transport
-        - Unloading deliveries and safely relocating the goods to their designated storage areas
-        - Ensuring forklift driving areas are free from spills or obstructions
-        - Regularly checking forklift equipment for faults or damages
-        - Consolidating partial pallets for incoming goods
-      """.trimIndent(),
-      offenceExclusions = "NONE,DRIVING",
-      isRollingOpportunity = false,
-      closingDate = LocalDate.of(2024, JULY, 20),
-      isOnlyForPrisonLeavers = true,
-      startDate = LocalDate.of(2024, JULY, 20),
-      howToApply = "",
-      supportingDocumentationRequired = "CV,DISCLOSURE_LETTER",
-      supportingDocumentationDetails = "",
-      employer = amazonEmployer,
-    )
-
-    val nonExistentEmployer = Employer(
-      id = EntityId("b9c925c1-c0d3-460d-8142-f79e7c292fce"),
-      name = "Non-Existent Employer",
-      description = "Daydreaming Inc.",
-      sector = "LOGISTICS",
-      status = "KEY_PARTNER",
-    )
-
-    val nonExistentJob = Job(
-      id = EntityId("035fa5bb-1523-4469-a2a6-c6cf0ac94173"),
-      title = "Non-Existent Job",
-      sector = "WAREHOUSING",
-      industrySector = "LOGISTICS",
-      numberOfVacancies = 2,
-      sourcePrimary = "PEL",
-      sourceSecondary = "",
-      charityName = "",
-      postcode = "LS12",
-      salaryFrom = 11.93f,
-      salaryTo = 15.90f,
-      salaryPeriod = "PER_HOUR",
-      additionalSalaryInformation = "",
-      isPayingAtLeastNationalMinimumWage = false,
-      workPattern = "FLEXIBLE_SHIFTS",
-      hoursPerWeek = "FULL_TIME",
-      contractType = "TEMPORARY",
-      baseLocation = "WORKPLACE",
-      essentialCriteria = "",
-      desirableCriteria = "",
-      description = """
-        This is a daydreaming job :)
-      """.trimIndent(),
-      offenceExclusions = "NONE,DRIVING",
-      isRollingOpportunity = false,
-      closingDate = LocalDate.of(2024, JULY, 20),
-      isOnlyForPrisonLeavers = true,
-      startDate = LocalDate.of(2024, JULY, 20),
-      howToApply = "",
-      supportingDocumentationRequired = "CV,DISCLOSURE_LETTER",
-      supportingDocumentationDetails = "",
-      employer = nonExistentEmployer,
-    )
-
-    val expectedPrisonNumber = "A1234BC"
-  }
 
   @BeforeEach
   fun setUp() {
@@ -195,7 +83,7 @@ class ExpressionOfInterestRepositoryShould {
   fun `save prisoner's ExpressionOfInterest to an existing job`() {
     val job = obtainTheJobJustCreated()
 
-    val savedExpressionOfInterest = makeExpressionOfInterest(job, expectedPrisonNumber).let { expressionOfInterest ->
+    val savedExpressionOfInterest = makeExpressionOfInterest(job, VALID_PRISON_NUMBER).let { expressionOfInterest ->
       expressionOfInterestRepository.saveAndFlush(expressionOfInterest)
     }
 
@@ -208,7 +96,7 @@ class ExpressionOfInterestRepositoryShould {
   fun `set createdAt attribute, when saving a new ExpressionOfInterest`() {
     val job = obtainTheJobJustCreated()
 
-    val expressionOfInterest = makeExpressionOfInterest(job, expectedPrisonNumber)
+    val expressionOfInterest = makeExpressionOfInterest(job, VALID_PRISON_NUMBER)
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobRegisterExpressionOfInterestTime))
     val savedExpressionOfInterest = expressionOfInterestRepository.saveAndFlush(expressionOfInterest)
 
@@ -220,7 +108,7 @@ class ExpressionOfInterestRepositoryShould {
     val job = obtainTheJobJustCreated()
 
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobRegisterExpressionOfInterestTime))
-    val savedExpressionOfInterest = makeExpressionOfInterest(job, expectedPrisonNumber).let { expressionOfInterest ->
+    val savedExpressionOfInterest = makeExpressionOfInterest(job, VALID_PRISON_NUMBER).let { expressionOfInterest ->
       expressionOfInterestRepository.saveAndFlush(expressionOfInterest)
     }
 
@@ -233,7 +121,7 @@ class ExpressionOfInterestRepositoryShould {
   fun `do NOT update ExpressionOfInterest, when it exists`() {
     val job = obtainTheJobJustCreated()
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobRegisterExpressionOfInterestTime))
-    val savedExpressionOfInterest = makeExpressionOfInterest(job, expectedPrisonNumber).let { expressionOfInterest ->
+    val savedExpressionOfInterest = makeExpressionOfInterest(job, VALID_PRISON_NUMBER).let { expressionOfInterest ->
       expressionOfInterestRepository.saveAndFlush(expressionOfInterest)
     }
 
@@ -241,7 +129,7 @@ class ExpressionOfInterestRepositoryShould {
       job = savedExpressionOfInterest.job,
       prisonNumber = savedExpressionOfInterest.id.prisonNumber,
     )
-    whenever(dateTimeProvider.now).thenReturn(Optional.of(jobReRegisterExpressionOfInterestTime))
+    whenever(dateTimeProvider.now).thenReturn(Optional.of(jobRegisterExpressionOfInterestTime.plus(1, DAYS)))
     val updatedExpressionOfInterest = expressionOfInterestRepository.saveAndFlush(duplicateExpressionOfInterest).also {
       entityManager.refresh(it)
     }
@@ -253,7 +141,7 @@ class ExpressionOfInterestRepositoryShould {
   @Test
   fun `throw exception, when saving ExpressionOfInterest with non-existent job`() {
     val jobId = nonExistentJob.id.toString()
-    val expressionOfInterest = makeExpressionOfInterest(nonExistentJob, expectedPrisonNumber)
+    val expressionOfInterest = makeExpressionOfInterest(nonExistentJob, VALID_PRISON_NUMBER)
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobRegisterExpressionOfInterestTime))
 
     val exception = assertThrows<Exception> {
@@ -270,7 +158,7 @@ class ExpressionOfInterestRepositoryShould {
   fun `delete prisoner's ExpressionOfInterest from an existing job`() {
     val job = obtainTheJobJustCreated()
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobRegisterExpressionOfInterestTime))
-    val savedExpressionOfInterest = makeExpressionOfInterest(job, expectedPrisonNumber).let { expressionOfInterest ->
+    val savedExpressionOfInterest = makeExpressionOfInterest(job, VALID_PRISON_NUMBER).let { expressionOfInterest ->
       expressionOfInterestRepository.saveAndFlush(expressionOfInterest)
     }
 
@@ -284,7 +172,7 @@ class ExpressionOfInterestRepositoryShould {
   fun `do NOT update job's attribute, when deleting existing ExpressionOfInterest`() {
     val job = obtainTheJobJustCreated()
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobRegisterExpressionOfInterestTime))
-    val savedExpressionOfInterest = makeExpressionOfInterest(job, expectedPrisonNumber).let { expressionOfInterest ->
+    val savedExpressionOfInterest = makeExpressionOfInterest(job, VALID_PRISON_NUMBER).let { expressionOfInterest ->
       expressionOfInterestRepository.saveAndFlush(expressionOfInterest)
     }
 
@@ -295,8 +183,8 @@ class ExpressionOfInterestRepositoryShould {
   }
 
   private fun obtainTheJobJustCreated(): Job {
-    employerRepository.save(amazonEmployer)
-    return jobRepository.save(amazonForkliftOperatorJob).also {
+    employerRepository.save(amazon)
+    return jobRepository.save(amazonForkliftOperator).also {
       entityManager.flush()
     }
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/JobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/JobRepositoryShould.kt
@@ -16,15 +16,13 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.jobsboard.api.config.TestJpaConfig
-import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.Employer
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
-import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
-import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.JobRepository
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.jobCreationTime
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.jobModificationTime
 import uk.gov.justice.digital.hmpps.jobsboard.api.testcontainers.PostgresContainer
-import java.time.Instant
-import java.time.LocalDate
-import java.time.Month.JULY
 import java.util.*
 
 @DataJpaTest
@@ -43,67 +41,6 @@ class JobRepositoryShould {
 
   @Autowired
   private lateinit var jobRepository: JobRepository
-
-  private val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
-  private val jobModificationTime = Instant.parse("2025-02-02T01:00:00Z")
-
-  private val amazonEmployer = Employer(
-    id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),
-    name = "Amazon",
-    description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
-    sector = "LOGISTICS",
-    status = "KEY_PARTNER",
-  )
-
-  private val amazonForkliftOperatorJob = Job(
-    id = EntityId("fe5d5175-5a21-4cec-a30b-fd87a5f76ce7"),
-    title = "Forklift operator",
-    sector = "WAREHOUSING",
-    industrySector = "LOGISTICS",
-    numberOfVacancies = 2,
-    sourcePrimary = "PEL",
-    sourceSecondary = "",
-    charityName = "",
-    postcode = "LS12",
-    salaryFrom = 11.93f,
-    salaryTo = 15.90f,
-    salaryPeriod = "PER_HOUR",
-    additionalSalaryInformation = "",
-    isPayingAtLeastNationalMinimumWage = false,
-    workPattern = "FLEXIBLE_SHIFTS",
-    hoursPerWeek = "FULL_TIME",
-    contractType = "TEMPORARY",
-    baseLocation = "WORKPLACE",
-    essentialCriteria = "",
-    desirableCriteria = "",
-    description = """
-      What's on offer:
-
-      - 5 days over 7, 05:30 to 15:30
-      - Paid weekly
-      - Immediate starts available
-      - Full training provided
-
-      Your duties will include:
-
-      - Manoeuvring forklifts safely in busy industrial environments
-      - Safely stacking and unstacking large quantities of goods onto shelves or pallets
-      - Moving goods from storage areas to loading areas for transport
-      - Unloading deliveries and safely relocating the goods to their designated storage areas
-      - Ensuring forklift driving areas are free from spills or obstructions
-      - Regularly checking forklift equipment for faults or damages
-      - Consolidating partial pallets for incoming goods
-    """.trimIndent(),
-    offenceExclusions = "NONE,DRIVING",
-    isRollingOpportunity = false,
-    closingDate = LocalDate.of(2024, JULY, 20),
-    isOnlyForPrisonLeavers = true,
-    startDate = LocalDate.of(2024, JULY, 20),
-    howToApply = "",
-    supportingDocumentationRequired = "CV,DISCLOSURE_LETTER",
-    supportingDocumentationDetails = "",
-    employer = amazonEmployer,
-  )
 
   @BeforeEach
   fun setUp() {
@@ -128,22 +65,22 @@ class JobRepositoryShould {
 
   @Test
   fun `save a new Job`() {
-    employerRepository.save(amazonEmployer)
-    jobRepository.save(amazonForkliftOperatorJob)
+    employerRepository.save(amazon)
+    jobRepository.save(amazonForkliftOperator)
   }
 
   @Test
   fun `set createdAt attribute when saving a new Job`() {
-    employerRepository.save(amazonEmployer)
-    val savedJob = jobRepository.save(amazonForkliftOperatorJob)
+    employerRepository.save(amazon)
+    val savedJob = jobRepository.save(amazonForkliftOperator)
 
     assertThat(savedJob.createdAt).isEqualTo(jobCreationTime)
   }
 
   @Test
   fun `not update createdAt attribute when updating an existing Job`() {
-    employerRepository.save(amazonEmployer)
-    val savedJob = jobRepository.save(amazonForkliftOperatorJob)
+    employerRepository.save(amazon)
+    val savedJob = jobRepository.save(amazonForkliftOperator)
 
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobModificationTime))
     val updatedJob = jobRepository.save(savedJob)
@@ -153,19 +90,19 @@ class JobRepositoryShould {
 
   @Test
   fun `set modifiedAt attribute with same value as createdAt when saving a new Job`() {
-    employerRepository.save(amazonEmployer)
-    val savedJob = jobRepository.save(amazonForkliftOperatorJob)
+    employerRepository.save(amazon)
+    val savedJob = jobRepository.save(amazonForkliftOperator)
 
     assertThat(savedJob.modifiedAt).isEqualTo(jobCreationTime)
   }
 
   @Test
   fun `update modifiedAt attribute with current date and time when updating an existing Job`() {
-    employerRepository.save(amazonEmployer)
-    jobRepository.save(amazonForkliftOperatorJob)
+    employerRepository.save(amazon)
+    jobRepository.save(amazonForkliftOperator)
 
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobModificationTime))
-    val updatedJob = jobRepository.saveAndFlush(amazonForkliftOperatorJob)
+    val updatedJob = jobRepository.saveAndFlush(amazonForkliftOperator)
 
     assertThat(updatedJob.modifiedAt).isEqualTo(jobModificationTime)
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobMother.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerM
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.tesco
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
-import java.time.Instant
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.TestPrototypes.Companion.jobCreationTime
 import java.time.LocalDate
 
 object JobMother {
@@ -43,15 +43,6 @@ object JobMother {
     supportingDocumentationRequired = "[\"DISCLOSURE_LETTER\", \"OTHER\"]",
     supportingDocumentationDetails = null,
     employer = tesco,
-  )
-
-  fun tescoWarehouseHandlerJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
-    employerId = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
-    employerName = "Tesco",
-    jobTitle = "Warehouse handler",
-    numberOfVacancies = 1,
-    sector = "WAREHOUSING",
-    createdAt = createdAt.toString(),
   )
 
   val amazonForkliftOperator = Job(
@@ -104,15 +95,6 @@ object JobMother {
     employer = amazon,
   )
 
-  fun amazonForkliftOperatorJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
-    employerId = "bf392249-b360-4e3e-81a0-8497047987e8",
-    employerName = "Amazon",
-    jobTitle = "Forklift operator",
-    numberOfVacancies = 2,
-    sector = "RETAIL",
-    createdAt = createdAt.toString(),
-  )
-
   val abcConstructionApprentice = Job(
     id = EntityId("6fdf2bf4-cfe6-419c-bab2-b3673adbb393"),
     title = "Apprentice plasterer",
@@ -146,17 +128,9 @@ object JobMother {
     employer = abcConstruction,
   )
 
-  fun abcConstructionJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
-    employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-    employerName = "ABC Construction",
-    jobTitle = "Apprentice plasterer",
-    numberOfVacancies = 3,
-    sector = "CONSTRUCTION",
-    createdAt = createdAt.toString(),
-  )
-
   val Job.requestBody: String get() = jobRequestBody(this)
   val Job.responseBody: String get() = jobResponseBody(this)
+  val Job.itemListResponseBody: String get() = jobItemListResponseBody(this)
 
   private fun jobRequestBody(job: Job): String {
     return jobBody(job)
@@ -166,7 +140,20 @@ object JobMother {
     return jobBody(job)
   }
 
-  fun newJobItemListResponse(
+  private fun jobItemListResponseBody(job: Job): String {
+    return """
+        {
+          "employerId": "${job.employer.id.id}",
+          "employerName": "${job.employer.name}",
+          "jobTitle": "${job.title}",
+          "numberOfVacancies": ${job.numberOfVacancies},
+          "sector": "${job.sector}",
+          "createdAt": "$jobCreationTime"
+        }
+    """.trimIndent()
+  }
+
+  private fun jobItemListResponseBody(
     employerId: String,
     employerName: String,
     jobTitle: String,
@@ -224,11 +211,6 @@ object JobMother {
   }
 
   private fun String.asJson(): String {
-    val mapper: ObjectMapper = jacksonObjectMapper()
-    return mapper.writeValueAsString(this)
-  }
-
-  private fun List<String>.asJson(): String {
     val mapper: ObjectMapper = jacksonObjectMapper()
     return mapper.writeValueAsString(this)
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobMother.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerM
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.tesco
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
+import java.time.Instant
 import java.time.LocalDate
 
 object JobMother {
@@ -42,6 +43,15 @@ object JobMother {
     supportingDocumentationRequired = "[\"DISCLOSURE_LETTER\", \"OTHER\"]",
     supportingDocumentationDetails = null,
     employer = tesco,
+  )
+
+  fun tescoWarehouseHandlerJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
+    employerId = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
+    employerName = "Tesco",
+    jobTitle = "Warehouse handler",
+    numberOfVacancies = 1,
+    sector = "WAREHOUSING",
+    createdAt = createdAt.toString(),
   )
 
   val amazonForkliftOperator = Job(
@@ -94,6 +104,15 @@ object JobMother {
     employer = amazon,
   )
 
+  fun amazonForkliftOperatorJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
+    employerId = "bf392249-b360-4e3e-81a0-8497047987e8",
+    employerName = "Amazon",
+    jobTitle = "Forklift operator",
+    numberOfVacancies = 2,
+    sector = "RETAIL",
+    createdAt = createdAt.toString(),
+  )
+
   val abcConstructionApprentice = Job(
     id = EntityId("6fdf2bf4-cfe6-419c-bab2-b3673adbb393"),
     title = "Apprentice plasterer",
@@ -127,14 +146,23 @@ object JobMother {
     employer = abcConstruction,
   )
 
+  fun abcConstructionJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
+    employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
+    employerName = "ABC Construction",
+    jobTitle = "Apprentice plasterer",
+    numberOfVacancies = 3,
+    sector = "CONSTRUCTION",
+    createdAt = createdAt.toString(),
+  )
+
   val Job.requestBody: String get() = jobRequestBody(this)
   val Job.responseBody: String get() = jobResponseBody(this)
 
-  fun jobRequestBody(job: Job): String {
+  private fun jobRequestBody(job: Job): String {
     return jobBody(job)
   }
 
-  fun jobResponseBody(job: Job): String {
+  private fun jobResponseBody(job: Job): String {
     return jobBody(job)
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -5,9 +5,12 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerM
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.amazon
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.tesco
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionApprentice
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionJobItemListResponse
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperatorJobItemListResponse
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.responseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandler
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandlerJobItemListResponse
 
 class JobsGetShould : JobsTestCase() {
   @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -5,12 +5,10 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerM
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.amazon
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.tesco
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionApprentice
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionJobItemListResponse
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperatorJobItemListResponse
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.itemListResponseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.responseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandler
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandlerJobItemListResponse
 
 class JobsGetShould : JobsTestCase() {
   @Test
@@ -59,9 +57,9 @@ class JobsGetShould : JobsTestCase() {
 
     assertGetJobsIsOK(
       expectedResponse = expectedResponseListOf(
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
-        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
-        abcConstructionJobItemListResponse(jobCreationTime),
+        amazonForkliftOperator.itemListResponseBody,
+        tescoWarehouseHandler.itemListResponseBody,
+        abcConstructionApprentice.itemListResponseBody,
       ),
     )
   }
@@ -76,7 +74,7 @@ class JobsGetShould : JobsTestCase() {
         size = 1,
         page = 1,
         totalElements = 3,
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+        amazonForkliftOperator.itemListResponseBody,
       ),
     )
   }
@@ -88,7 +86,7 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobsIsOK(
       parameters = "jobTitleOrEmployerName=Forklift operator",
       expectedResponse = expectedResponseListOf(
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+        amazonForkliftOperator.itemListResponseBody,
       ),
     )
   }
@@ -100,7 +98,7 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobsIsOK(
       parameters = "jobTitleOrEmployerName=operator",
       expectedResponse = expectedResponseListOf(
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+        amazonForkliftOperator.itemListResponseBody,
       ),
     )
   }
@@ -112,7 +110,7 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobsIsOK(
       parameters = "jobTitleOrEmployerName=Tesco",
       expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+        tescoWarehouseHandler.itemListResponseBody,
       ),
     )
   }
@@ -124,7 +122,7 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobsIsOK(
       parameters = "jobTitleOrEmployerName=Tes",
       expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+        tescoWarehouseHandler.itemListResponseBody,
       ),
     )
   }
@@ -136,7 +134,7 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobsIsOK(
       parameters = "sector=retail",
       expectedResponse = expectedResponseListOf(
-        amazonForkliftOperatorJobItemListResponse(jobCreationTime),
+        amazonForkliftOperator.itemListResponseBody,
       ),
     )
   }
@@ -158,7 +156,7 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobsIsOK(
       parameters = "jobTitleOrEmployerName=er&sector=construction",
       expectedResponse = expectedResponseListOf(
-        abcConstructionJobItemListResponse(jobCreationTime),
+        abcConstructionApprentice.itemListResponseBody,
       ),
     )
   }
@@ -173,7 +171,7 @@ class JobsGetShould : JobsTestCase() {
         size = 1,
         page = 0,
         totalElements = 1,
-        tescoWarehouseHandlerJobItemListResponse(jobCreationTime),
+        tescoWarehouseHandler.itemListResponseBody,
       ),
     )
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerM
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerTestCase
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionApprentice
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
-import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.newJobItemListResponse
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.requestBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandler
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
@@ -144,33 +143,6 @@ class JobsTestCase : EmployerTestCase() {
 
     assertAddExpressionOfInterest("6fdf2bf4-cfe6-419c-bab2-b3673adbb393", prisonNumber)
   }
-
-  protected fun abcConstructionJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
-    employerId = "182e9a24-6edb-48a6-a84f-b7061f004a97",
-    employerName = "ABC Construction",
-    jobTitle = "Apprentice plasterer",
-    numberOfVacancies = 3,
-    sector = "CONSTRUCTION",
-    createdAt = createdAt.toString(),
-  )
-
-  protected fun tescoWarehouseHandlerJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
-    employerId = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
-    employerName = "Tesco",
-    jobTitle = "Warehouse handler",
-    numberOfVacancies = 1,
-    sector = "WAREHOUSING",
-    createdAt = createdAt.toString(),
-  )
-
-  protected fun amazonForkliftOperatorJobItemListResponse(createdAt: Instant): String = newJobItemListResponse(
-    employerId = "bf392249-b360-4e3e-81a0-8497047987e8",
-    employerName = "Amazon",
-    jobTitle = "Forklift operator",
-    numberOfVacancies = 2,
-    sector = "RETAIL",
-    createdAt = createdAt.toString(),
-  )
 
   protected fun String.asJson(): String {
     val mapper: ObjectMapper = jacksonObjectMapper()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ArchivedRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ArchivedRepositoryShould.kt
@@ -19,7 +19,7 @@ class ArchivedRepositoryShould : JobRepositoryTestCase() {
 
   @Test
   fun `archive a job for given prisoner`() {
-    val job = obtainTheJobJustCreated()
+    val job = givenAJobHasBeenCreated()
 
     val savedJobArchived = makeJobArchived(job, expectedPrisonNumber).let { jobArchived ->
       archivedRepository.saveAndFlush(jobArchived)
@@ -32,7 +32,7 @@ class ArchivedRepositoryShould : JobRepositoryTestCase() {
 
   @Test
   fun `set createdAt attribute, when archiving job`() {
-    val job = obtainTheJobJustCreated()
+    val job = givenAJobHasBeenCreated()
 
     val jobArchived = makeJobArchived(job, expectedPrisonNumber)
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobArchivedTime))
@@ -43,7 +43,7 @@ class ArchivedRepositoryShould : JobRepositoryTestCase() {
 
   @Test
   fun `do NOT update job's attribute, when archiving job`() {
-    val job = obtainTheJobJustCreated()
+    val job = givenAJobHasBeenCreated()
 
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobArchivedTime))
     val savedJobArchived = makeJobArchived(job, expectedPrisonNumber).let { jobArchived ->
@@ -57,7 +57,7 @@ class ArchivedRepositoryShould : JobRepositoryTestCase() {
 
   @Test
   fun `do NOT archive again, when it exists`() {
-    val job = obtainTheJobJustCreated()
+    val job = givenAJobHasBeenCreated()
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobArchivedTime))
     val savedJobArchived = makeJobArchived(job, expectedPrisonNumber).let { jobArchived ->
       archivedRepository.saveAndFlush(jobArchived)
@@ -94,7 +94,7 @@ class ArchivedRepositoryShould : JobRepositoryTestCase() {
 
   @Test
   fun `undo archiving a job for given prisoner`() {
-    val job = obtainTheJobJustCreated()
+    val job = givenAJobHasBeenCreated()
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobArchivedTime))
     val savedJobArchived = makeJobArchived(job, expectedPrisonNumber).let { jobArchived ->
       archivedRepository.saveAndFlush(jobArchived)
@@ -108,7 +108,7 @@ class ArchivedRepositoryShould : JobRepositoryTestCase() {
 
   @Test
   fun `do NOT update job's attribute, when undo archiving`() {
-    val job = obtainTheJobJustCreated()
+    val job = givenAJobHasBeenCreated()
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobArchivedTime))
     val savedJobArchived = makeJobArchived(job, expectedPrisonNumber).let { jobArchived ->
       archivedRepository.saveAndFlush(jobArchived)

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepositoryTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepositoryTestCase.kt
@@ -19,7 +19,7 @@ abstract class JobRepositoryTestCase : RepositoryTestCase() {
   protected lateinit var jobRepository: JobRepository
 
   protected final val jobCreationTime: Instant = TestPrototypes.jobCreationTime
-  protected final val expectedPrisonNumber = TestPrototypes.expectedPrisonNumber
+  protected final val expectedPrisonNumber = TestPrototypes.VALID_PRISON_NUMBER
   protected final val nonExistentJob = TestPrototypes.nonExistentJob
 
   @BeforeEach

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepositoryTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/JobRepositoryTestCase.kt
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.jobsboard.api.commons.domain.RepositoryTestCase
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.amazon
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
 import java.time.Instant
 import java.util.*
@@ -17,12 +19,7 @@ abstract class JobRepositoryTestCase : RepositoryTestCase() {
   protected lateinit var jobRepository: JobRepository
 
   protected final val jobCreationTime: Instant = TestPrototypes.jobCreationTime
-  protected final val jobModificationTime: Instant = TestPrototypes.jobModificationTime
   protected final val expectedPrisonNumber = TestPrototypes.expectedPrisonNumber
-
-  protected final val amazonEmployer = TestPrototypes.amazonEmployer
-  protected final val amazonForkliftOperatorJob = TestPrototypes.amazonForkliftOperatorJob
-
   protected final val nonExistentJob = TestPrototypes.nonExistentJob
 
   @BeforeEach
@@ -32,9 +29,9 @@ abstract class JobRepositoryTestCase : RepositoryTestCase() {
     whenever(dateTimeProvider.now).thenReturn(Optional.of(jobCreationTime))
   }
 
-  protected fun obtainTheJobJustCreated(): Job {
-    employerRepository.save(amazonEmployer)
-    return jobRepository.save(amazonForkliftOperatorJob).also {
+  protected fun givenAJobHasBeenCreated(): Job {
+    employerRepository.save(amazon)
+    return jobRepository.save(amazonForkliftOperator).also {
       entityManager.flush()
     }
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepositoryJobDetailsShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepositoryJobDetailsShould.kt
@@ -19,7 +19,7 @@ class MatchingCandidateJobRepositoryJobDetailsShould : JobRepositoryTestCase() {
 
   @Test
   fun `retrieve by prison number`() {
-    val expectedJob = this.obtainTheJobJustCreated()
+    val expectedJob = this.givenAJobHasBeenCreated()
 
     val actual = findJobDetailsByPrisonNumber(expectedJob.id.id, expectedPrisonNumber)
 
@@ -32,7 +32,7 @@ class MatchingCandidateJobRepositoryJobDetailsShould : JobRepositoryTestCase() {
 
   @Test
   fun `retrieve with relevant ExpressionOfInterest and Archived`() {
-    val expectedJob = obtainTheJobJustCreated().apply {
+    val expectedJob = givenAJobHasBeenCreated().apply {
       val makeMoreRecords: (String) -> Unit = { prisonNumber ->
         this.registerExpressionOfInterest(prisonNumber).also { expressionOfInterestRepository.save(it) }
         this.archivedBy(prisonNumber).also { archivedRepository.save(it) }
@@ -56,7 +56,7 @@ class MatchingCandidateJobRepositoryJobDetailsShould : JobRepositoryTestCase() {
 
   @Test
   fun `retrieve without relevant ExpressionOfInterest nor Archived`() {
-    val expectedJob = obtainTheJobJustCreated().apply {
+    val expectedJob = givenAJobHasBeenCreated().apply {
       registerExpressionOfInterest(unexpectedPrisonNumber).also { expressionOfInterestRepository.save(it) }
       archivedBy(unexpectedPrisonNumber).also { archivedRepository.save(it) }
     }.also { entityManager.flush() }
@@ -73,7 +73,7 @@ class MatchingCandidateJobRepositoryJobDetailsShould : JobRepositoryTestCase() {
 
   @Test
   fun `retrieve with relevant ExpressionOfInterest only`() {
-    val expectedJob = obtainTheJobJustCreated().apply {
+    val expectedJob = givenAJobHasBeenCreated().apply {
       registerExpressionOfInterest(expectedPrisonNumber).also { expressionOfInterestRepository.save(it) }
     }.also { entityManager.flush() }
 
@@ -87,7 +87,7 @@ class MatchingCandidateJobRepositoryJobDetailsShould : JobRepositoryTestCase() {
 
   @Test
   fun `retrieve with relevant Archived only`() {
-    val expectedJob = obtainTheJobJustCreated().apply {
+    val expectedJob = givenAJobHasBeenCreated().apply {
       archivedBy(expectedPrisonNumber).also { archivedRepository.save(it) }
     }.also { entityManager.flush() }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/TestPrototypes.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/TestPrototypes.kt
@@ -8,10 +8,14 @@ import java.time.Month.JULY
 
 class TestPrototypes {
   companion object {
-    val defaultCreationTime = Instant.parse("2024-01-01T00:00:00Z")
-    val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
+    val defaultCreationTime: Instant = Instant.parse("2024-01-01T00:00:00Z")
+    val employerCreationTime = Instant.parse("2024-07-01T01:00:00Z")
+    val employerModificationTime = Instant.parse("2024-07-01T02:00:00Z")
+    val jobCreationTime: Instant = Instant.parse("2024-01-01T00:00:00Z")
+    val jobModificationTime = Instant.parse("2025-02-02T01:00:00Z")
+    val jobRegisterExpressionOfInterestTime = Instant.parse("2025-03-01T01:00:00Z")
 
-    val nonExistentEmployer = Employer(
+    private val nonExistentEmployer = Employer(
       id = EntityId("b9c925c1-c0d3-460d-8142-f79e7c292fce"),
       name = "Non-Existent Employer",
       description = "Daydreaming Inc.",
@@ -54,6 +58,6 @@ class TestPrototypes {
       employer = nonExistentEmployer,
     )
 
-    val expectedPrisonNumber = "A1234BC"
+    const val VALID_PRISON_NUMBER = "A1234BC"
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/TestPrototypes.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/TestPrototypes.kt
@@ -10,65 +10,6 @@ class TestPrototypes {
   companion object {
     val defaultCreationTime = Instant.parse("2024-01-01T00:00:00Z")
     val jobCreationTime = Instant.parse("2024-01-01T00:00:00Z")
-    val jobModificationTime = Instant.parse("2025-02-02T01:00:00Z")
-
-    val amazonEmployer = Employer(
-      id = EntityId("eaf7e96e-e45f-461d-bbcb-fd4cedf0499c"),
-      name = "Amazon",
-      description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
-      sector = "LOGISTICS",
-      status = "KEY_PARTNER",
-    )
-
-    val amazonForkliftOperatorJob = Job(
-      id = EntityId("fe5d5175-5a21-4cec-a30b-fd87a5f76ce7"),
-      title = "Forklift operator",
-      sector = "WAREHOUSING",
-      industrySector = "LOGISTICS",
-      numberOfVacancies = 2,
-      sourcePrimary = "PEL",
-      sourceSecondary = "",
-      charityName = "",
-      postcode = "LS12",
-      salaryFrom = 11.93f,
-      salaryTo = 15.90f,
-      salaryPeriod = "PER_HOUR",
-      additionalSalaryInformation = "",
-      isPayingAtLeastNationalMinimumWage = false,
-      workPattern = "FLEXIBLE_SHIFTS",
-      hoursPerWeek = "FULL_TIME",
-      contractType = "TEMPORARY",
-      baseLocation = "WORKPLACE",
-      essentialCriteria = "",
-      desirableCriteria = "",
-      description = """
-        What's on offer:
-  
-        - 5 days over 7, 05:30 to 15:30
-        - Paid weekly
-        - Immediate starts available
-        - Full training provided
-  
-        Your duties will include:
-  
-        - Manoeuvring forklifts safely in busy industrial environments
-        - Safely stacking and unstacking large quantities of goods onto shelves or pallets
-        - Moving goods from storage areas to loading areas for transport
-        - Unloading deliveries and safely relocating the goods to their designated storage areas
-        - Ensuring forklift driving areas are free from spills or obstructions
-        - Regularly checking forklift equipment for faults or damages
-        - Consolidating partial pallets for incoming goods
-      """.trimIndent(),
-      offenceExclusions = "NONE,DRIVING",
-      isRollingOpportunity = false,
-      closingDate = LocalDate.of(2024, JULY, 20),
-      isOnlyForPrisonLeavers = true,
-      startDate = LocalDate.of(2024, JULY, 20),
-      howToApply = "",
-      supportingDocumentationRequired = "CV,DISCLOSURE_LETTER",
-      supportingDocumentationDetails = "",
-      employer = amazonEmployer,
-    )
 
     val nonExistentEmployer = Employer(
       id = EntityId("b9c925c1-c0d3-460d-8142-f79e7c292fce"),


### PR DESCRIPTION
This PR continues with the refactors to simplify the access to the data used for creation and assertion in our tests.   It moves all the logic to create the expected test list items to the job mother object, removing duplicated code.