### PR TITLE
[ESWE-865] Candidate matching avoid archived jobs

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/ApplicationTestCase.kt
@@ -174,7 +174,20 @@ abstract class ApplicationTestCase {
     return arrayOf(finalJobId, finalPrisonNumber)
   }
 
-  protected fun assertRequestArchived(
+  protected fun assertAddArchived(
+    jobId: String? = null,
+    prisonNumber: String? = null,
+    expectedStatus: HttpStatus = CREATED,
+    matchRedirectedUrl: Boolean = false,
+  ): Array<String> = assertEditArchived(
+    jobId = jobId,
+    prisonNumber = prisonNumber,
+    expectedStatus = expectedStatus,
+    expectedHttpVerb = PUT,
+    matchRedirectedUrl = matchRedirectedUrl,
+  )
+
+  protected fun assertEditArchived(
     jobId: String? = null,
     prisonNumber: String? = null,
     expectedStatus: HttpStatus,
@@ -194,19 +207,6 @@ abstract class ApplicationTestCase {
     )
     return arrayOf(finalJobId, finalPrisonNumber)
   }
-
-  protected fun assertAddArchived(
-    jobId: String? = null,
-    prisonNumber: String? = null,
-    expectedStatus: HttpStatus = CREATED,
-    matchRedirectedUrl: Boolean = false,
-  ): Array<String> = assertRequestArchived(
-    jobId = jobId,
-    prisonNumber = prisonNumber,
-    expectedStatus = expectedStatus,
-    expectedHttpVerb = PUT,
-    matchRedirectedUrl = matchRedirectedUrl,
-  )
 
   protected fun randomUUID(): String = UUID.randomUUID().toString()
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/ArchivedTestCase.kt
@@ -43,7 +43,7 @@ abstract class ArchivedTestCase : JobsTestCase() {
     jobId: String,
     prisonNumber: String,
     expectedStatus: HttpStatus = NO_CONTENT,
-  ): Array<String> = assertRequestArchived(
+  ): Array<String> = assertEditArchived(
     jobId = jobId,
     prisonNumber = prisonNumber,
     expectedStatus = expectedStatus,
@@ -64,7 +64,7 @@ abstract class ArchivedTestCase : JobsTestCase() {
     expectedStatus: HttpStatus = BAD_REQUEST,
     expectedHttpVerb: HttpMethod,
     expectedResponse: String? = null,
-  ) = assertRequestArchived(
+  ) = assertEditArchived(
     jobId = jobId,
     prisonNumber = prisonNumber,
     expectedStatus = expectedStatus,

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -49,6 +49,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       @Test
       fun `return Jobs that have not been archived for the candidate`() {
         assertAddArchived(amazonForkliftOperator.id.id, prisonNumber)
+        assertAddArchived(amazonForkliftOperator.id.id, anotherPrisonNumber)
         assertAddArchived(tescoWarehouseHandler.id.id, anotherPrisonNumber)
 
         assertGetMatchingCandidateJobsIsOK(
@@ -67,41 +68,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       @Test
       fun `return Jobs tagged with candidate's interest`() {
         assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
-
-        assertGetMatchingCandidateJobsIsOK(
-          parameters = "prisonNumber=$prisonNumber",
-          expectedResponse = expectedResponseListOf(
-            tescoWarehouseHandler.candidateMatchingItemListResponseBody,
-            amazonForkliftOperator.candidateMatchingItemListResponseBody,
-            builder()
-              .from(abcConstructionApprentice)
-              .withExpressionOfInterestFrom(prisonNumber)
-              .build().candidateMatchingItemListResponseBody,
-          ),
-        )
-      }
-
-      @Test
-      fun `return Jobs avoiding others candidates interests`() {
-        assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
         assertAddExpressionOfInterest(abcConstructionApprentice.id.id, anotherPrisonNumber)
-
-        assertGetMatchingCandidateJobsIsOK(
-          parameters = "prisonNumber=$prisonNumber",
-          expectedResponse = expectedResponseListOf(
-            tescoWarehouseHandler.candidateMatchingItemListResponseBody,
-            amazonForkliftOperator.candidateMatchingItemListResponseBody,
-            builder()
-              .from(abcConstructionApprentice)
-              .withExpressionOfInterestFrom(prisonNumber)
-              .build().candidateMatchingItemListResponseBody,
-          ),
-        )
-      }
-
-      @Test
-      fun `return Jobs avoiding others candidates different jobs interests`() {
-        assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
         assertAddExpressionOfInterest(tescoWarehouseHandler.id.id, anotherPrisonNumber)
 
         assertGetMatchingCandidateJobsIsOK(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionApprentice
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
@@ -7,181 +10,189 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.buil
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.candidateMatchingItemListResponseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandler
 
+@DisplayName("Matching Candidate GET Should")
 class MatchingCandidateGetShould : MatchingCandidateTestCase() {
 
-  @Test
-  fun `retrieve a default paginated empty matching candidate Jobs list`() {
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber",
-      expectedResponse = expectedResponseListOf(),
-    )
+  @Nested
+  @DisplayName("Given Job Board has no jobs")
+  inner class GivenJobBoardHasNoJobs {
+    @Test
+    fun `return a default paginated empty matching candidate Jobs list`() {
+      assertGetMatchingCandidateJobsIsOK(
+        parameters = "prisonNumber=$prisonNumber",
+        expectedResponse = expectedResponseListOf(),
+      )
+    }
   }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list`() {
-    givenThreeJobsAreCreated()
+  @Nested
+  @DisplayName("Given Job Board has jobs")
+  inner class GivenJobsBoardHasJobs {
+    @BeforeEach
+    fun beforeEach() = givenThreeJobsAreCreated()
 
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber",
-      expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandler.candidateMatchingItemListResponseBody,
-        amazonForkliftOperator.candidateMatchingItemListResponseBody,
-        abcConstructionApprentice.candidateMatchingItemListResponseBody,
-      ),
-    )
-  }
+    @Test
+    fun `return a default paginated matching candidate Jobs list`() {
+      assertGetMatchingCandidateJobsIsOK(
+        parameters = "prisonNumber=$prisonNumber",
+        expectedResponse = expectedResponseListOf(
+          tescoWarehouseHandler.candidateMatchingItemListResponseBody,
+          amazonForkliftOperator.candidateMatchingItemListResponseBody,
+          abcConstructionApprentice.candidateMatchingItemListResponseBody,
+        ),
+      )
+    }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list given a candidate interested on a job`() {
-    givenThreeJobsAreCreated()
-    assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
+    @Nested
+    @DisplayName("And candidates expressed interest")
+    inner class AndCandidatesExpressed {
+      @Test
+      fun `return Jobs tagged with candidate's interest`() {
+        assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
 
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber",
-      expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandler.candidateMatchingItemListResponseBody,
-        amazonForkliftOperator.candidateMatchingItemListResponseBody,
-        builder()
-          .from(abcConstructionApprentice)
-          .withExpressionOfInterestFrom(prisonNumber)
-          .build().candidateMatchingItemListResponseBody,
-      ),
-    )
-  }
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = "prisonNumber=$prisonNumber",
+          expectedResponse = expectedResponseListOf(
+            tescoWarehouseHandler.candidateMatchingItemListResponseBody,
+            amazonForkliftOperator.candidateMatchingItemListResponseBody,
+            builder()
+              .from(abcConstructionApprentice)
+              .withExpressionOfInterestFrom(prisonNumber)
+              .build().candidateMatchingItemListResponseBody,
+          ),
+        )
+      }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list given different candidates interested on the same job`() {
-    givenThreeJobsAreCreated()
-    assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
-    assertAddExpressionOfInterest(abcConstructionApprentice.id.id, anotherPrisonNumber)
+      @Test
+      fun `return Jobs avoiding others candidates interests`() {
+        assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
+        assertAddExpressionOfInterest(abcConstructionApprentice.id.id, anotherPrisonNumber)
 
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber",
-      expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandler.candidateMatchingItemListResponseBody,
-        amazonForkliftOperator.candidateMatchingItemListResponseBody,
-        builder()
-          .from(abcConstructionApprentice)
-          .withExpressionOfInterestFrom(prisonNumber)
-          .build().candidateMatchingItemListResponseBody,
-      ),
-    )
-  }
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = "prisonNumber=$prisonNumber",
+          expectedResponse = expectedResponseListOf(
+            tescoWarehouseHandler.candidateMatchingItemListResponseBody,
+            amazonForkliftOperator.candidateMatchingItemListResponseBody,
+            builder()
+              .from(abcConstructionApprentice)
+              .withExpressionOfInterestFrom(prisonNumber)
+              .build().candidateMatchingItemListResponseBody,
+          ),
+        )
+      }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list given different candidates interested on different jobs`() {
-    givenThreeJobsAreCreated()
-    assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
-    assertAddExpressionOfInterest(tescoWarehouseHandler.id.id, anotherPrisonNumber)
+      @Test
+      fun `return Jobs avoiding others candidates different jobs interests`() {
+        assertAddExpressionOfInterest(abcConstructionApprentice.id.id, prisonNumber)
+        assertAddExpressionOfInterest(tescoWarehouseHandler.id.id, anotherPrisonNumber)
 
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber",
-      expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandler.candidateMatchingItemListResponseBody,
-        amazonForkliftOperator.candidateMatchingItemListResponseBody,
-        builder()
-          .from(abcConstructionApprentice)
-          .withExpressionOfInterestFrom(prisonNumber)
-          .build().candidateMatchingItemListResponseBody,
-      ),
-    )
-  }
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = "prisonNumber=$prisonNumber",
+          expectedResponse = expectedResponseListOf(
+            tescoWarehouseHandler.candidateMatchingItemListResponseBody,
+            amazonForkliftOperator.candidateMatchingItemListResponseBody,
+            builder()
+              .from(abcConstructionApprentice)
+              .withExpressionOfInterestFrom(prisonNumber)
+              .build().candidateMatchingItemListResponseBody,
+          ),
+        )
+      }
 
-  @Test
-  fun `retrieve a custom paginated matching candidate Jobs list`() {
-    givenThreeJobsAreCreated()
+    }
 
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber&page=1&size=1",
-      expectedResponse = expectedResponseListOf(
-        size = 1,
-        page = 1,
-        totalElements = 3,
-        amazonForkliftOperator.candidateMatchingItemListResponseBody,
-      ),
-    )
-  }
+    @Nested
+    @DisplayName("And a custom pagination has been set")
+    inner class CustomPagination {
+      @Test
+      fun `return a custom paginated matching candidate Jobs list`() {
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = "prisonNumber=$prisonNumber&page=1&size=1",
+          expectedResponse = expectedResponseListOf(
+            size = 1,
+            page = 1,
+            totalElements = 3,
+            amazonForkliftOperator.candidateMatchingItemListResponseBody,
+          ),
+        )
+      }
+    }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list filtered by job sector`() {
-    givenThreeJobsAreCreated()
+    @Nested
+    @DisplayName("And a custom filter has been set")
+    inner class CustomFilter {
+      @Test
+      fun `return Jobs filtered by job sector`() {
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = "prisonNumber=$prisonNumber&sectors=retail",
+          expectedResponse = expectedResponseListOf(
+            amazonForkliftOperator.candidateMatchingItemListResponseBody,
+          ),
+        )
+      }
 
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber&sectors=retail",
-      expectedResponse = expectedResponseListOf(
-        amazonForkliftOperator.candidateMatchingItemListResponseBody,
-      ),
-    )
-  }
+      @Test
+      fun `return Jobs filtered by various job sectors`() {
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = "prisonNumber=$prisonNumber&sectors=retail,warehousing",
+          expectedResponse = expectedResponseListOf(
+            tescoWarehouseHandler.candidateMatchingItemListResponseBody,
+            amazonForkliftOperator.candidateMatchingItemListResponseBody,
+          ),
+        )
+      }
+    }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list filtered by job sectors`() {
-    givenThreeJobsAreCreated()
+    @Nested
+    @DisplayName("And a custom sorting order has been set")
+    inner class AndOrderHasBeenSet {
+      @Test
+      fun `return Jobs list sorted by job title, in ascending order`() {
+        assertGetMatchingCandidateJobsIsOKAndSortedByJobTitle(
+          parameters = "prisonNumber=$prisonNumber&sortBy=jobTitle&sortOrder=asc",
+          expectedJobTitlesSorted = listOf(
+            "Apprentice plasterer",
+            "Forklift operator",
+            "Warehouse handler",
+          ),
+        )
+      }
 
-    assertGetMatchingCandidateJobsIsOK(
-      parameters = "prisonNumber=$prisonNumber&sectors=retail,warehousing",
-      expectedResponse = expectedResponseListOf(
-        tescoWarehouseHandler.candidateMatchingItemListResponseBody,
-        amazonForkliftOperator.candidateMatchingItemListResponseBody,
-      ),
-    )
-  }
+      @Test
+      fun `return Jobs sorted by job title, in descending order`() {
+        assertGetMatchingCandidateJobsIsOKAndSortedByJobTitle(
+          parameters = "prisonNumber=$prisonNumber&sortBy=jobTitle&sortOrder=desc",
+          expectedJobTitlesSorted = listOf(
+            "Warehouse handler",
+            "Forklift operator",
+            "Apprentice plasterer",
+          ),
+        )
+      }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list sorted by job title, in ascending order`() {
-    givenThreeJobsAreCreated()
+      @Test
+      fun `return Jobs sorted by closing date, in ascending order, by default`() {
+        assertGetMatchingCandidateJobsIsOKAndSortedByClosingDate(
+          parameters = "prisonNumber=$prisonNumber&sortBy=closingDate",
+          expectedSortingOrder = "asc",
+        )
+      }
 
-    assertGetMatchingCandidateJobsIsOKAndSortedByJobTitle(
-      parameters = "prisonNumber=$prisonNumber&sortBy=jobTitle&sortOrder=asc",
-      expectedJobTitlesSorted = listOf(
-        "Apprentice plasterer",
-        "Forklift operator",
-        "Warehouse handler",
-      ),
-    )
-  }
+      @Test
+      fun `return Jobs sorted by closing date, in ascending order`() {
+        assertGetMatchingCandidateJobsIsOKAndSortedByClosingDate(
+          parameters = "prisonNumber=$prisonNumber&sortBy=closingDate&sortOrder=asc",
+          expectedSortingOrder = "asc",
+        )
+      }
 
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list sorted by job title, in descending order`() {
-    givenThreeJobsAreCreated()
-
-    assertGetMatchingCandidateJobsIsOKAndSortedByJobTitle(
-      parameters = "prisonNumber=$prisonNumber&sortBy=jobTitle&sortOrder=desc",
-      expectedJobTitlesSorted = listOf(
-        "Warehouse handler",
-        "Forklift operator",
-        "Apprentice plasterer",
-      ),
-    )
-  }
-
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list sorted by closing date, in ascending order, by default`() {
-    givenThreeJobsAreCreated()
-
-    assertGetMatchingCandidateJobsIsOKAndSortedByClosingDate(
-      parameters = "prisonNumber=$prisonNumber&sortBy=closingDate",
-      expectedSortingOrder = "asc",
-    )
-  }
-
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list sorted by closing date, in ascending order`() {
-    givenThreeJobsAreCreated()
-
-    assertGetMatchingCandidateJobsIsOKAndSortedByClosingDate(
-      parameters = "prisonNumber=$prisonNumber&sortBy=closingDate&sortOrder=asc",
-      expectedSortingOrder = "asc",
-    )
-  }
-
-  @Test
-  fun `retrieve a default paginated matching candidate Jobs list sorted by closing date, in descending order`() {
-    givenThreeJobsAreCreated()
-
-    assertGetMatchingCandidateJobsIsOKAndSortedByClosingDate(
-      parameters = "prisonNumber=$prisonNumber&sortBy=closingDate&sortOrder=desc",
-      expectedSortingOrder = "desc",
-    )
+      @Test
+      fun `return Jobs sorted by closing date, in descending order`() {
+        assertGetMatchingCandidateJobsIsOKAndSortedByClosingDate(
+          parameters = "prisonNumber=$prisonNumber&sortBy=closingDate&sortOrder=desc",
+          expectedSortingOrder = "desc",
+        )
+      }
+    }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -44,6 +44,24 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
     }
 
     @Nested
+    @DisplayName("And jobs has been archived")
+    inner class AndJobsHasBeenArchived {
+      @Test
+      fun `return Jobs that have not been archived for the candidate`() {
+        assertAddArchived(amazonForkliftOperator.id.id, prisonNumber)
+        assertAddArchived(tescoWarehouseHandler.id.id, anotherPrisonNumber)
+
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = "prisonNumber=$prisonNumber",
+          expectedResponse = expectedResponseListOf(
+            tescoWarehouseHandler.candidateMatchingItemListResponseBody,
+            abcConstructionApprentice.candidateMatchingItemListResponseBody,
+          ),
+        )
+      }
+    }
+
+    @Nested
     @DisplayName("And candidates expressed interest")
     inner class AndCandidatesExpressed {
       @Test
@@ -98,7 +116,6 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
           ),
         )
       }
-
     }
 
     @Nested

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -28,7 +28,9 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     FROM Job j
     LEFT JOIN ExpressionOfInterest eoi ON eoi.job.id.id = j.id.id AND eoi.id.prisonNumber = :prisonNumber
     LEFT JOIN Employer e ON j.employer.id.id = e.id.id
+    LEFT JOIN Archived a ON a.job.id.id = j.id.id AND a.id.prisonNumber = :prisonNumber
     WHERE (:sectors IS NULL OR LOWER(j.sector) IN :sectors)
+    AND a.id IS NULL
   """,
   )
   fun findAll(


### PR DESCRIPTION
This PR:
- Proposes a new way to name Candidate Matching test naming, reducing duplication and structuring them using nested classes.
- Filters jobs that have not been archived for a candidate.
- Removes duplication and makes tests more compact for `archiving` and `expressions of interest`, extending the scenario's setup to cover a larger area.