### PR TITLE
[ESWE-865] Candidate matching returns an error on missing prison number parameter

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -13,6 +13,21 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tesc
 @DisplayName("Matching Candidate GET Should")
 class MatchingCandidateGetShould : MatchingCandidateTestCase() {
 
+  @Test
+  fun `return BAD REQUEST error when prison number is missing`() {
+    assertGetMatchingCandidateJobsReturnsBadRequestError(
+      expectedResponse = """
+        {
+            "status": 400,
+            "errorCode": null,
+            "userMessage": "Missing required parameter: Required request parameter 'prisonNumber' for method parameter type String is not present",
+            "developerMessage": "Required request parameter 'prisonNumber' for method parameter type String is not present",
+            "moreInfo": null
+        }
+      """.trimIndent(),
+    )
+  }
+
   @Nested
   @DisplayName("Given Job Board has no jobs")
   inner class GivenJobBoardHasNoJobs {
@@ -76,9 +91,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
           expectedResponse = expectedResponseListOf(
             tescoWarehouseHandler.candidateMatchingItemListResponseBody,
             amazonForkliftOperator.candidateMatchingItemListResponseBody,
-            builder()
-              .from(abcConstructionApprentice)
-              .withExpressionOfInterestFrom(prisonNumber)
+            builder().from(abcConstructionApprentice).withExpressionOfInterestFrom(prisonNumber)
               .build().candidateMatchingItemListResponseBody,
           ),
         )

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateTestCase.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs
 
+import org.springframework.http.HttpMethod.GET
+import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.OK
 
 const val MATCHING_CANDIDATE_ENDPOINT = "${JOBS_ENDPOINT}/matching-candidate"
@@ -42,6 +44,17 @@ abstract class MatchingCandidateTestCase : JobsTestCase() {
       url = url,
       expectedStatus = OK,
       expectedClosingDateSortingOrder = expectedSortingOrder,
+    )
+  }
+
+  protected fun assertGetMatchingCandidateJobsReturnsBadRequestError(
+    expectedResponse: String? = null,
+  ) {
+    assertRequestWithoutBody(
+      url = MATCHING_CANDIDATE_ENDPOINT,
+      expectedStatus = BAD_REQUEST,
+      expectedHttpVerb = GET,
+      expectedResponse = expectedResponse,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/HmppsJobsBoardApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/HmppsJobsBoardApiExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
@@ -60,6 +61,20 @@ class HmppsJobsBoardApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Illegal Argument: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException::class)
+  fun handleMissingParams(e: MissingServletRequestParameterException): ResponseEntity<ErrorResponse> {
+    log.info("Missing required parameter: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "Missing required parameter: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobDetailsRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobDetailsRetriever.kt
@@ -14,7 +14,7 @@ class MatchingCandidateJobDetailsRetriever(
 ) {
   fun retrieve(jobId: String, prisonNumber: String? = null): MatchingCandidateJobDetails? {
     return when {
-      (prisonNumber == null || prisonNumber.isEmpty()) -> jobRepository.findById(EntityId(jobId)).getOrNull()
+      prisonNumber.isNullOrEmpty() -> jobRepository.findById(EntityId(jobId)).getOrNull()
         ?.let { job -> MatchingCandidateJobDetails(job) }
 
       else -> matchingCandidateJobsRepository.findJobDetailsByPrisonNumber(jobId, prisonNumber).firstOrNull()


### PR DESCRIPTION
The matching candidate endpoints need the `Prison Number` parameter to be present.  This small PR adds proper message and HTTP status to model this error.