### PR TITLE
[ESWE-965] View job returns not found

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amaz
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.itemListResponseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.responseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandler
+import java.util.UUID
 
 class JobsGetShould : JobsTestCase() {
   @Test
@@ -41,6 +42,15 @@ class JobsGetShould : JobsTestCase() {
     assertGetJobIsOK(
       jobId = jobId,
       expectedResponse = tescoWarehouseHandler.responseBody,
+    )
+  }
+
+  @Test
+  fun `returns Not Found when a Job doesn't exist`() {
+    val nonExistingJobId = UUID.randomUUID().toString()
+    assertGetJobThrowsNotFoundError(
+      jobId = nonExistingJobId,
+      errorMessage = "Job with Id $nonExistingJobId not found",
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGetShould.kt
@@ -34,7 +34,7 @@ class JobsGetShould : JobsTestCase() {
   }
 
   @Test
-  fun `return null on empty optional fields`() {
+  fun `return a Job with all optional fields empty as null`() {
     assertAddEmployerIsCreated(employer = tesco)
     val jobId = assertAddJobIsCreated(job = tescoWarehouseHandler)
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.OK
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerTestCase
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionApprentice
@@ -105,6 +106,25 @@ class JobsTestCase : EmployerTestCase() {
       url = url,
       expectedStatus = OK,
       expectedResponse = expectedResponse,
+    )
+  }
+
+  protected fun assertGetJobThrowsNotFoundError(
+    jobId: String,
+    errorMessage: String,
+  ) {
+    assertResponse(
+      url = "$JOBS_ENDPOINT/$jobId",
+      expectedStatus = NOT_FOUND,
+      expectedResponse = """
+        {
+          "status":404,
+          "errorCode":null,
+          "userMessage":"No resource found failure: $errorMessage",
+          "developerMessage":$errorMessage",
+          "moreInfo":null
+        }
+      """.trimIndent(),
     )
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsTestCase.kt
@@ -120,8 +120,8 @@ class JobsTestCase : EmployerTestCase() {
         {
           "status":404,
           "errorCode":null,
-          "userMessage":"No resource found failure: $errorMessage",
-          "developerMessage":$errorMessage",
+          "userMessage":"No Job found failure: $errorMessage",
+          "developerMessage":"$errorMessage",
           "moreInfo":null
         }
       """.trimIndent(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/HmppsJobsBoardApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/config/HmppsJobsBoardApiExceptionHandler.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.JobNotFoundException
 
 @RestControllerAdvice
 class HmppsJobsBoardApiExceptionHandler {
@@ -41,6 +42,17 @@ class HmppsJobsBoardApiExceptionHandler {
         developerMessage = e.message,
       ),
     ).also { log.info("No resource found exception: {}", e.message) }
+
+  @ExceptionHandler(JobNotFoundException::class)
+  fun handleJobNotFoundException(e: JobNotFoundException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(NOT_FOUND)
+    .body(
+      ErrorResponse(
+        status = NOT_FOUND,
+        userMessage = "No Job found failure: ${e.message}",
+        developerMessage = e.message,
+      ),
+    ).also { log.info("No Job found exception: {}", e.message) }
 
   @ExceptionHandler(AccessDeniedException::class)
   fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobNotFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobNotFoundException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
+
+class JobNotFoundException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/JobRetriever.kt
@@ -13,7 +13,8 @@ class JobRetriever(
 ) {
 
   fun retrieve(id: String): Job {
-    return jobRepository.findById(EntityId(id)).orElseThrow()
+    return jobRepository.findById(EntityId(id))
+      .orElseThrow { JobNotFoundException("Job with Id $id not found") }
   }
 
   fun retrieveAllJobs(jobTitleOrEmployerName: String?, sector: String?, pageable: Pageable): Page<Job> {


### PR DESCRIPTION
This PR is necessary to fix a bug. When a job doesn't exist, it will return a 404 Not Found.