### PR TITLE
[ESWE-861] Open applications

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/infrastructure/ApplicationRepositoryTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/infrastructure/ApplicationRepositoryTestCase.kt
@@ -4,7 +4,13 @@ import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.Application
 import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.ApplicationRepository
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToAbcConstructionApprentice
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToAmazonForkliftOperator
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToTescoWarehouseHandler
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.infrastructure.JobRepositoryTestCase
 
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -15,5 +21,37 @@ abstract class ApplicationRepositoryTestCase : JobRepositoryTestCase() {
   @AfterEach
   fun tearDown() {
     applicationRepository.deleteAll()
+  }
+
+  protected fun givenAnApplicationMade(): Application {
+    val application = applicationBuilder(job = givenAJobHasBeenCreated()).build()
+    return applicationRepository.saveAndFlush(application)
+  }
+
+  protected fun givenThreeApplicationsMade(): List<Application> {
+    val applications = mutableListOf<Application>()
+    listOf(
+      applicationToTescoWarehouseHandler,
+      applicationToAmazonForkliftOperator,
+      applicationToAbcConstructionApprentice,
+    ).forEach {
+      employerRepository.save(it.job.employer)
+      val job = jobRepository.saveAndFlush(it.job)
+      val savedApplication = ApplicationMother.builder().from(it).apply { this.job = job }.build().run {
+        applicationRepository.saveAndFlush(this)
+      }
+      applications.add(savedApplication)
+    }
+    return applications
+  }
+
+  private fun applicationBuilder(job: Job? = null) = ApplicationMother.builder().apply {
+    ApplicationMother.KnownApplicant.let {
+      prisonNumber = it.prisonNumber
+      firstName = it.firstName
+      lastName = it.lastName
+      prisonId = it.prisonId
+      job?.let { this.job = job }
+    }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationMother.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications
 
 import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.Application
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.abcConstructionApprentice
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amazonForkliftOperator
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandler
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.asJson
@@ -39,6 +40,16 @@ object ApplicationMother {
     lastName = KnownApplicant.lastName,
     status = "APPLICATION_MADE",
     job = amazonForkliftOperator,
+  )
+
+  val applicationToAbcConstructionApprentice = Application(
+    id = EntityId("1b635092-048f-4c88-b673-103e5e702122"),
+    prisonNumber = KnownApplicant.prisonNumber,
+    prisonId = KnownApplicant.prisonId,
+    firstName = KnownApplicant.firstName,
+    lastName = KnownApplicant.lastName,
+    status = "UNSUCCESSFUL_AT_INTERVIEW",
+    job = abcConstructionApprentice,
   )
 
   fun builder() = ApplicationBuilder()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsByPrisonerTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsByPrisonerTestCase.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications
+
+import org.springframework.http.HttpMethod.GET
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.OK
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.Application
+
+const val OPEN_APPLICATIONS_ENDPOINT = "$APPLICATIONS_ENDPOINT/open"
+
+abstract class ApplicationsByPrisonerTestCase(
+  val endpoint: String,
+) : ApplicationsTestCase() {
+  protected fun assertGetApplicationsByPrisonerIsOk(
+    parameters: String,
+    expectedResponse: String? = null,
+  ) = assertGetApplicationsByPrisoner(parameters, OK, expectedResponse)
+
+  protected fun assertGetApplicationsByPrisonerReturnsBadRequestError(
+    parameters: String? = null,
+    expectedResponse: String? = null,
+  ) = assertGetApplicationsByPrisoner(parameters, BAD_REQUEST, expectedResponse)
+
+  private fun assertGetApplicationsByPrisoner(
+    parameters: String? = null,
+    expectedStatus: HttpStatus = OK,
+    expectedResponse: String? = null,
+  ) {
+    assertRequestWithoutBody(
+      url = "$endpoint${parameters?.let { "?$it" } ?: ""}",
+      expectedHttpVerb = GET,
+      expectedStatus = expectedStatus,
+      expectedResponse = expectedResponse,
+    )
+  }
+
+  protected val Application.responseBody get() = applicationResponseBody(this)
+
+  private fun applicationResponseBody(application: Application): String {
+    return application.let {
+      """
+      {
+        "id": "${it.id}",
+        "jobId": "${it.job.id}",
+        "employerName": "${it.job.employer.name}",
+        "jobTitle": "${it.job.title}",
+        "applicationStatus": "${it.status}",
+        "createdAt": "$jobCreationTime",
+        "lastModifiedAt": "$jobCreationTime"
+      }
+      """.trimIndent()
+    }
+  }
+}
+
+abstract class OpenApplicationsTestCase : ApplicationsByPrisonerTestCase(OPEN_APPLICATIONS_ENDPOINT) {
+  fun assertGetOpenApplicationsIsOk(
+    parameters: String,
+    expectedResponse: String? = null,
+  ) = assertGetApplicationsByPrisonerIsOk(parameters, expectedResponse)
+
+  fun assertGetOpenApplicationsReturnsBadRequestError(
+    parameters: String? = null,
+    expectedResponse: String? = null,
+  ) = assertGetApplicationsByPrisonerReturnsBadRequestError(parameters, expectedResponse)
+}

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsTestCase.kt
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus.OK
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.Application
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToAbcConstructionApprentice
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToAmazonForkliftOperator
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToTescoWarehouseHandler
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.requestBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobsTestCase
 import uk.gov.justice.digital.hmpps.jobsboard.api.employers.domain.EmployerRepository
@@ -24,6 +27,16 @@ abstract class ApplicationsTestCase : JobsTestCase() {
   fun tearDown() {
     employerRepository.deleteAll()
   }
+
+  protected fun assertAddApplicationIsCreated(
+    application: Application,
+    expectedResponse: String? = null,
+  ) = assertAddApplication(application, CREATED, expectedResponse)
+
+  protected fun assertUpdateApplicationIsOk(
+    application: Application,
+    expectedResponse: String? = null,
+  ) = assertUpdateApplication(application, OK, expectedResponse)
 
   protected fun assertAddApplication(
     application: Application,
@@ -50,6 +63,22 @@ abstract class ApplicationsTestCase : JobsTestCase() {
             { "status":400,"errorCode":null,"userMessage":"Illegal Argument: $expectedErrorMessage","developerMessage":"${expectedDeveloperMessage ?: expectedErrorMessage}" }
         """.trimIndent(),
       )
+    }
+  }
+
+  protected fun givenThreeApplicationsAreCreated() {
+    givenApplicationsAreCreated(
+      applicationToAmazonForkliftOperator,
+      applicationToTescoWarehouseHandler,
+      applicationToAbcConstructionApprentice,
+    )
+  }
+
+  protected fun givenApplicationsAreCreated(vararg applications: Application) {
+    applications.forEach {
+      assertAddEmployerIsCreated(it.job.employer)
+      assertAddJobIsCreated(it.job)
+      assertAddApplicationIsCreated(it)
     }
   }
 

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/OpenApplicationsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/OpenApplicationsGetShould.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToAmazonForkliftOperator
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications.ApplicationMother.applicationToTescoWarehouseHandler
+
+class OpenApplicationsGetShould : OpenApplicationsTestCase() {
+  private val knownApplicant = ApplicationMother.KnownApplicant
+
+  @Test
+  fun `return an error, when missing prisonNumber`() {
+    assertGetOpenApplicationsReturnsBadRequestError()
+  }
+
+  @Test
+  fun `return an empty list, for unknown prisoner`() {
+    assertGetOpenApplicationsIsOk("prisonNumber=X9876YZ", expectedResponseListOf())
+  }
+
+  @Nested
+  @DisplayName("Given no application has been made, for the given prisoner")
+  inner class GivenNoApplication {
+    @Test
+    fun `return a default paginated list of open applications`() {
+      assertGetOpenApplicationsIsOk("prisonNumber=${knownApplicant.prisonNumber}", expectedResponseListOf())
+    }
+  }
+
+  @Nested
+  @DisplayName("Given some applications have been made, for the given prisoner")
+  inner class GivenSomeApplications {
+    @BeforeEach
+    fun setUp() {
+      givenThreeApplicationsAreCreated()
+    }
+
+    @Test
+    fun `return a paginated list of open applications`() {
+      assertGetOpenApplicationsIsOk(
+        parameters = "prisonNumber=${knownApplicant.prisonNumber}",
+        expectedResponse = expectedResponseListOf(
+          size = 10,
+          page = 0,
+          totalElements = 2,
+          applicationToAmazonForkliftOperator.responseBody,
+          applicationToTescoWarehouseHandler.responseBody,
+        ),
+      )
+    }
+
+    @Nested
+    @DisplayName("And a custom pagination has been set")
+    inner class CustomPagination {
+      @Test
+      fun `return a custom paginated list of open applications`() {
+        assertGetOpenApplicationsIsOk(
+          parameters = "prisonNumber=${knownApplicant.prisonNumber}&page=1&size=1",
+          expectedResponse = expectedResponseListOf(
+            size = 1,
+            page = 1,
+            totalElements = 2,
+            applicationToTescoWarehouseHandler.responseBody,
+          ),
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/application/ApplicationByPrisonerRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/application/ApplicationByPrisonerRetriever.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.applications.application
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.Application
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.ApplicationRepository
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.ApplicationStatus
+
+@Service
+class ApplicationByPrisonerRetriever(
+  private val applicationRepository: ApplicationRepository,
+) {
+  private val openStatus = ApplicationStatus.openStatus.map { it.name }
+
+  fun retrieveAllOpenApplications(prisonNumber: String, pageable: Pageable): Page<Application> {
+    return applicationRepository.findByPrisonNumberAndStatusIn(prisonNumber, openStatus, pageable)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/application/GetApplicationsByPrisonerResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/application/GetApplicationsByPrisonerResponse.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.applications.application
+
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain.Application
+
+data class GetApplicationsByPrisonerResponse(
+  val id: String,
+  val jobId: String,
+  val employerName: String,
+  val jobTitle: String,
+  val applicationStatus: String,
+  val createdAt: String,
+  val lastModifiedAt: String,
+) {
+  companion object {
+    fun from(application: Application) = application.run {
+      GetApplicationsByPrisonerResponse(
+        id = id.id,
+        jobId = job.id.id,
+        employerName = job.employer.name,
+        jobTitle = job.title,
+        applicationStatus = status,
+        createdAt = createdAt.toString(),
+        lastModifiedAt = lastModifiedAt.toString(),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/domain/ApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/domain/ApplicationRepository.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.repository.history.RevisionRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 @Repository
-interface ApplicationRepository : JpaRepository<Application, EntityId>, RevisionRepository<Application, EntityId, Long>
+interface ApplicationRepository : JpaRepository<Application, EntityId>, RevisionRepository<Application, EntityId, Long> {
+
+  fun findByPrisonNumberAndStatusIn(prisonNumber: String, status: List<String>, pageable: Pageable): Page<Application>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/domain/ApplicationStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/applications/domain/ApplicationStatus.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.applications.domain
+
+enum class ApplicationStatus {
+  APPLICATION_MADE,
+  APPLICATION_UNSUCCESSFUL,
+  SELECTED_FOR_INTERVIEW,
+  INTERVIEW_BOOKED,
+  UNSUCCESSFUL_AT_INTERVIEW,
+  JOB_OFFER,
+  ;
+
+  companion object {
+    val openStatus = listOf(APPLICATION_MADE, SELECTED_FOR_INTERVIEW, INTERVIEW_BOOKED)
+    val closedStatus = listOf(APPLICATION_UNSUCCESSFUL, UNSUCCESSFUL_AT_INTERVIEW, JOB_OFFER)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsGet.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.controller.applications
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction.ASC
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.application.ApplicationByPrisonerRetriever
+import uk.gov.justice.digital.hmpps.jobsboard.api.applications.application.GetApplicationsByPrisonerResponse
+import uk.gov.justice.digital.hmpps.jobsboard.api.config.ErrorResponse
+
+@Validated
+@RestController
+@RequestMapping("/applications", produces = [APPLICATION_JSON_VALUE])
+class ApplicationsGet(
+  private val applicationsRetriever: ApplicationByPrisonerRetriever,
+) {
+  @PreAuthorize("hasAnyRole('ROLE_EDUCATION_WORK_PLAN_VIEW','ROLE_EDUCATION_WORK_PLAN_EDIT')")
+  @GetMapping("/open")
+  @Operation(
+    summary = "Retrieve open applications of the given prisoner",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The success status is set as the request has been processed correctly.",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The failure status is set when the request is invalid. An error response will be provided.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Error: Unauthorised. The error status is set as the required authorisation was not provided.",
+        content = [Content()],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Error: Access Denied. The error status is set as the required system role(s) was/were not found.",
+        content = [Content()],
+      ),
+    ],
+  )
+  fun retrieveOpenApplications(
+    @RequestParam(required = true)
+    @Parameter(description = "The identifier (prison number) of the given prisoner")
+    prisonNumber: String,
+    @RequestParam(defaultValue = "0")
+    page: Int,
+    @RequestParam(defaultValue = "10")
+    size: Int,
+  ): ResponseEntity<Page<GetApplicationsByPrisonerResponse>> {
+    val pageable: Pageable = PageRequest.of(page, size, Sort.by(ASC, "createdAt"))
+    val openApplications = applicationsRetriever.retrieveAllOpenApplications(prisonNumber, pageable)
+    val response = openApplications.map { GetApplicationsByPrisonerResponse.from(it) }
+    return ResponseEntity.ok(response)
+  }
+}


### PR DESCRIPTION
This PR add new endpoint `/applications/open` under `/applications` for listing all open applications of given prisoner

- Pagination has been added. 
- Pagination parameters are optional
- Repository, retriever and response are shared with closed application (upcoming changes next)