### PR TITLE
[ESWE-865] Updating null postcode coordinates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationService.kt
@@ -13,22 +13,24 @@ class PostcodeLocationService(
   private val uuidGenerator: UUIDGenerator,
 ) {
   fun save(postcode: String) {
-    if (postcodesRepository.existsByCode(postcode)) {
-      val savedPostcode = postcodesRepository.findByCode(postcode)
-      if (savedPostcode.xCoordinate != null && savedPostcode.yCoordinate != null) {
-        return
-      }
+    val savedPostcode = postcodesRepository.findByCode(postcode)
+
+    savedPostcode?.let {
+      if (it.xCoordinate != null && it.yCoordinate != null) return
     }
 
     val postcodeCoordinates = osPlacesAPIClient.getAddressesFor(postcode)
 
-    postcodesRepository.save(
-      Postcode(
-        id = EntityId(uuidGenerator),
-        code = postcode,
-        xCoordinate = postcodeCoordinates.xCoordinate,
-        yCoordinate = postcodeCoordinates.yCoordinate,
-      ),
+    val postcodeToSave = savedPostcode?.copy(
+      xCoordinate = postcodeCoordinates.xCoordinate,
+      yCoordinate = postcodeCoordinates.yCoordinate,
+    ) ?: Postcode(
+      id = EntityId(uuidGenerator),
+      code = postcode,
+      xCoordinate = postcodeCoordinates.xCoordinate,
+      yCoordinate = postcodeCoordinates.yCoordinate,
     )
+
+    postcodesRepository.save(postcodeToSave)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationService.kt
@@ -14,7 +14,10 @@ class PostcodeLocationService(
 ) {
   fun save(postcode: String) {
     if (postcodesRepository.existsByCode(postcode)) {
-      return
+      val savedPostcode = postcodesRepository.findByCode(postcode)
+      if (savedPostcode.xCoordinate != null && savedPostcode.yCoordinate != null) {
+        return
+      }
     }
 
     val postcodeCoordinates = osPlacesAPIClient.getAddressesFor(postcode)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodesRepository.kt
@@ -6,6 +6,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 @Repository
 interface PostcodesRepository : JpaRepository<Postcode, EntityId> {
-  fun existsByCode(postcode: String): Boolean
-  fun findByCode(postcode: String): Postcode
+  fun existsByCode(code: String): Boolean
+  fun findByCode(code: String): Postcode
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodesRepository.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
+import java.util.*
 
 @Repository
 interface PostcodesRepository : JpaRepository<Postcode, EntityId> {
-  fun existsByCode(code: String): Boolean
-  fun findByCode(code: String): Postcode
+  fun findByCode(code: String): Postcode?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodesRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodesRepository.kt
@@ -6,5 +6,6 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 
 @Repository
 interface PostcodesRepository : JpaRepository<Postcode, EntityId> {
-  fun existsByCode(code: String): Boolean
+  fun existsByCode(postcode: String): Boolean
+  fun findByCode(postcode: String): Postcode
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
@@ -35,27 +35,7 @@ class PostcodeLocationServiceShould {
   @InjectMocks
   private lateinit var postcodeLocationService: PostcodeLocationService
 
-  val postcodeId = randomUUID().toString()
-
-  val expectedPostcode = Postcode(
-    id = EntityId(postcodeId),
-    code = amazonForkliftOperator.postcode,
-    xCoordinate = 1.23f,
-    yCoordinate = 4.56f,
-  )
-
-  val expectedPostcodeWithNullCoordinates = Postcode(
-    id = EntityId(postcodeId),
-    code = amazonForkliftOperator.postcode,
-    xCoordinate = null,
-    yCoordinate = null,
-  )
-
-  val expectedLocation = OsPlacesApiDPA(
-    postcode = amazonForkliftOperator.postcode,
-    xCoordinate = expectedPostcode.xCoordinate,
-    yCoordinate = expectedPostcode.yCoordinate,
-  )
+  private val postcodeId = randomUUID().toString()
 
   @Nested
   @DisplayName("Given a postcode does not exist")
@@ -117,4 +97,24 @@ class PostcodeLocationServiceShould {
       }
     }
   }
+
+  private val expectedPostcode = Postcode(
+    id = EntityId(postcodeId),
+    code = amazonForkliftOperator.postcode,
+    xCoordinate = 1.23f,
+    yCoordinate = 4.56f,
+  )
+
+  private val expectedPostcodeWithNullCoordinates = Postcode(
+    id = EntityId(postcodeId),
+    code = amazonForkliftOperator.postcode,
+    xCoordinate = null,
+    yCoordinate = null,
+  )
+
+  private val expectedLocation = OsPlacesApiDPA(
+    postcode = amazonForkliftOperator.postcode,
+    xCoordinate = expectedPostcode.xCoordinate,
+    yCoordinate = expectedPostcode.yCoordinate,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
@@ -99,6 +99,9 @@ class PostcodeLocationServiceShould {
     inner class AndStoredCoordinatesAreNotNull {
       @Test
       fun `not save a postcode with coordinates`() {
+        whenever(postcodesRepository.findByCode(amazonForkliftOperator.postcode))
+          .thenReturn(expectedPostcode)
+
         postcodeLocationService.save(amazonForkliftOperator.postcode)
 
         verify(postcodesRepository, never()).save(any())
@@ -111,6 +114,8 @@ class PostcodeLocationServiceShould {
     inner class AndStoredCoordinatesAreNull {
       @Test
       fun `Update postcode with fresh coordinates`() {
+        whenever(uuidGenerator.generate())
+          .thenReturn(postcodeId)
         whenever(postcodesRepository.findByCode(amazonForkliftOperator.postcode))
           .thenReturn(expectedPostcodeWithNullCoordinates)
         whenever(osPlacesAPIClient.getAddressesFor(amazonForkliftOperator.postcode))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -67,8 +66,6 @@ class PostcodeLocationServiceShould {
         .thenReturn(postcodeId)
       whenever(osPlacesAPIClient.getAddressesFor(amazonForkliftOperator.postcode))
         .thenReturn(expectedLocation)
-      whenever(postcodesRepository.existsByCode(amazonForkliftOperator.postcode))
-        .thenReturn(false)
 
       postcodeLocationService.save(amazonForkliftOperator.postcode)
 
@@ -88,12 +85,6 @@ class PostcodeLocationServiceShould {
   @Nested
   @DisplayName("Given a postcode exists")
   inner class GivenPostcodeExisting {
-    @BeforeEach
-    fun setUp() {
-      whenever(postcodesRepository.existsByCode(amazonForkliftOperator.postcode))
-        .thenReturn(true)
-    }
-
     @Nested
     @DisplayName("And the stored coordinates are not null")
     inner class AndStoredCoordinatesAreNotNull {
@@ -114,8 +105,6 @@ class PostcodeLocationServiceShould {
     inner class AndStoredCoordinatesAreNull {
       @Test
       fun `Update postcode with fresh coordinates`() {
-        whenever(uuidGenerator.generate())
-          .thenReturn(postcodeId)
         whenever(postcodesRepository.findByCode(amazonForkliftOperator.postcode))
           .thenReturn(expectedPostcodeWithNullCoordinates)
         whenever(osPlacesAPIClient.getAddressesFor(amazonForkliftOperator.postcode))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -9,7 +8,6 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -49,16 +47,8 @@ class PostcodeLocationServiceShould {
 
       postcodeLocationService.save(amazonForkliftOperator.postcode)
 
-      val locationCaptor = argumentCaptor<String>()
-      verify(osPlacesAPIClient).getAddressesFor(locationCaptor.capture())
-      val actualLocation = locationCaptor.firstValue
-
-      val postcodeCaptor = argumentCaptor<Postcode>()
-      verify(postcodesRepository).save(postcodeCaptor.capture())
-      val actualPostcode = postcodeCaptor.firstValue
-
-      assertThat(actualLocation).isEqualTo(amazonForkliftOperator.postcode)
-      assertThat(actualPostcode).isEqualTo(expectedPostcode)
+      verify(osPlacesAPIClient).getAddressesFor(amazonForkliftOperator.postcode)
+      verify(postcodesRepository).save(expectedPostcode)
     }
   }
 
@@ -75,8 +65,8 @@ class PostcodeLocationServiceShould {
 
         postcodeLocationService.save(amazonForkliftOperator.postcode)
 
-        verify(postcodesRepository, never()).save(any())
         verify(osPlacesAPIClient, never()).getAddressesFor(any())
+        verify(postcodesRepository, never()).save(any())
       }
     }
 
@@ -92,8 +82,8 @@ class PostcodeLocationServiceShould {
 
         postcodeLocationService.save(amazonForkliftOperator.postcode)
 
-        verify(postcodesRepository).save(expectedPostcode)
         verify(osPlacesAPIClient).getAddressesFor(amazonForkliftOperator.postcode)
+        verify(postcodesRepository).save(expectedPostcode)
       }
     }
   }


### PR DESCRIPTION
If the OS Places API service is down, the coordinates for a postcode won't be available. In that case, we'll store null values.

This PR provides a self-healing feature. Every time a postcode is retrieved when saving or updating a Job, if the code has its coordinates to null, the service will try to recover them again.