### PR TITLE
[ESWE-888] Application search: fix bug of ignoring parameter `prisonerName`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/applications/ApplicationsGet.kt
@@ -251,6 +251,7 @@ class ApplicationsGet(
     val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, *sortByFields))
     val applications = applicationRetriever.retrieveAllApplicationsByPrisonId(
       prisonId,
+      prisonerName = prisonerName,
       status = applicationStatus,
       jobTitleOrEmployerName = jobTitleOrEmployerName,
       pageable = pageable,


### PR DESCRIPTION
This PR fixed the bug of ignoring parameter `prisonNumber` while searching.