### PR TITLE
[ESWE-1105] Increase Employer description length to 1000 (from 500)

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
@@ -57,7 +57,7 @@ class EmployersPutShould : EmployerTestCase() {
 
     @Test
     fun `not update an existing employer with validation error, as employer description is too long`() {
-      val employerBuilder = EmployerMother.builder().from(sainsburys).apply { description = ".".repeat(500) }
+      val employerBuilder = EmployerMother.builder().from(sainsburys).apply { description = ".".repeat(1000) }
       assertUpdateEmployerIsOk(
         employerId = employerId,
         body = employerBuilder.build().requestBody,
@@ -65,7 +65,7 @@ class EmployersPutShould : EmployerTestCase() {
 
       employerBuilder.description += "x"
 
-      val expectedError = "description - size must be between 0 and 500".let { error ->
+      val expectedError = "description - size must be between 0 and 1000".let { error ->
         """
         {"status":400,"errorCode":null,"userMessage":"Validation failure: $error","developerMessage":"$error","moreInfo":null}
         """.trimIndent()

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersPutShould.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers
 
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.requestBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.employers.EmployerMother.responseBody
@@ -29,18 +32,45 @@ class EmployersPutShould : EmployerTestCase() {
     )
   }
 
-  @Test
-  fun `update an existing Employer`() {
-    val employerId = assertAddEmployerIsCreated(employer = sainsburys)
+  @Nested
+  @DisplayName("Given an employer has been created")
+  inner class GivenAnEmployer {
+    private lateinit var employerId: String
 
-    assertUpdateEmployerIsOk(
-      employerId = employerId,
-      body = sainsburys.requestBody,
-    )
+    @BeforeEach
+    fun setUp() {
+      employerId = assertAddEmployerIsCreated(employer = sainsburys)
+    }
 
-    assertGetEmployerIsOK(
-      employerId = employerId,
-      expectedResponse = sainsburys.responseBody,
-    )
+    @Test
+    fun `update an existing Employer`() {
+      assertUpdateEmployerIsOk(
+        employerId = employerId,
+        body = sainsburys.requestBody,
+      )
+
+      assertGetEmployerIsOK(
+        employerId = employerId,
+        expectedResponse = sainsburys.responseBody,
+      )
+    }
+
+    @Test
+    fun `not update an existing employer with validation error, as employer description is too long`() {
+      val employerBuilder = EmployerMother.builder().from(sainsburys).apply { description = ".".repeat(500) }
+      assertUpdateEmployerIsOk(
+        employerId = employerId,
+        body = employerBuilder.build().requestBody,
+      )
+
+      employerBuilder.description += "x"
+
+      val expectedError = "description - size must be between 0 and 500".let { error ->
+        """
+        {"status":400,"errorCode":null,"userMessage":"Validation failure: $error","developerMessage":"$error","moreInfo":null}
+        """.trimIndent()
+      }
+      assertUpdateEmployerThrowsValidationError(employerId, employerBuilder.build().requestBody, expectedError)
+    }
   }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/employers/EmployersTestCase.kt
@@ -48,6 +48,19 @@ class EmployerTestCase : ApplicationTestCase() {
     )
   }
 
+  protected fun assertUpdateEmployerThrowsValidationError(
+    employerId: String,
+    body: String,
+    expectedResponse: String,
+  ) {
+    assertAddEmployer(
+      id = employerId,
+      body = body,
+      expectedStatus = BAD_REQUEST,
+      expectedResponse = expectedResponse,
+    )
+  }
+
   protected fun assertGetEmployerIsOK(
     employerId: String? = null,
     parameters: String? = null,
@@ -102,7 +115,7 @@ class EmployerTestCase : ApplicationTestCase() {
     expectedStatus: HttpStatus,
     expectedResponse: String? = null,
   ): String {
-    val employerId = id ?: randomUUID().toString()
+    val employerId = id ?: randomUUID()
     assertRequestWithBody(
       url = "$EMPLOYERS_ENDPOINT/$employerId",
       body = body,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/CreateEmployerRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/CreateEmployerRequest.kt
@@ -1,9 +1,12 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.employers.application
 
+import jakarta.validation.constraints.Size
+
 @ConsistentCopyVisibility
 data class CreateEmployerRequest internal constructor(
   val id: String = "",
   val name: String,
+  @field:Size(max = 500)
   val description: String,
   val sector: String,
   val status: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/CreateEmployerRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/application/CreateEmployerRequest.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size
 data class CreateEmployerRequest internal constructor(
   val id: String = "",
   val name: String,
-  @field:Size(max = 500)
+  @field:Size(max = 1000)
   val description: String,
   val sector: String,
   val status: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/domain/Employer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/employers/domain/Employer.kt
@@ -19,7 +19,7 @@ data class Employer(
   @Column(name = "name", nullable = false)
   val name: String,
 
-  @Column(name = "description", length = 500, nullable = false)
+  @Column(name = "description", length = 1000, nullable = false)
   val description: String,
 
   @Column(name = "sector", nullable = false)

--- a/src/main/resources/db/migration/V1_1__start.sql
+++ b/src/main/resources/db/migration/V1_1__start.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS employers
 (
     id               VARCHAR(36) PRIMARY KEY,
     name             VARCHAR(255) NOT NULL,
-    description      VARCHAR(500) NOT NULL,
+    description      VARCHAR(1000) NOT NULL,
     sector           VARCHAR(255) NOT NULL,
     status           VARCHAR(255) NOT NULL,
     created_by       VARCHAR(30)  NOT NULL,

--- a/src/main/resources/db/migration/V1_1__start.sql
+++ b/src/main/resources/db/migration/V1_1__start.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS employers
 (
     id               VARCHAR(36) PRIMARY KEY,
     name             VARCHAR(255) NOT NULL,
-    description      VARCHAR(1000) NOT NULL,
+    description      VARCHAR(500) NOT NULL,
     sector           VARCHAR(255) NOT NULL,
     status           VARCHAR(255) NOT NULL,
     created_by       VARCHAR(30)  NOT NULL,

--- a/src/main/resources/db/migration/V1_2__ESWE-1105_enlarge_employers_description.sql
+++ b/src/main/resources/db/migration/V1_2__ESWE-1105_enlarge_employers_description.sql
@@ -1,0 +1,2 @@
+ALTER TABLE employers
+ALTER COLUMN description TYPE VARCHAR(1000);


### PR DESCRIPTION
This PR increase the maximum length of employer's description from 500 to 1000.

1. DB column length is revised.
2. Validation has been added to API/controller