### PR TITLE
[ESWE-1106] Upgrade Spring Boot and suppress inapplicable vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.6"
-  kotlin("plugin.spring") version "2.0.20"
-  kotlin("plugin.jpa") version "2.0.20"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.8"
+  kotlin("plugin.spring") version "2.0.21"
+  kotlin("plugin.jpa") version "2.0.21"
   id("jvm-test-suite")
   id("jacoco")
 }
@@ -99,4 +99,8 @@ tasks {
       )
     }
   }
+}
+
+dependencyCheck {
+  suppressionFiles.add("jobs-board-suppressions.xml")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/helm_deploy/hmpps-jobs-board-api/Chart.yaml
+++ b/helm_deploy/hmpps-jobs-board-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-jobs-board-api
 version: 0.2.1
 dependencies:
   - name: generic-service
-    version: "3.4"
+    version: "3.6"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.8"
+    version: "1.10"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/jobs-board-suppressions.xml
+++ b/jobs-board-suppressions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        Suppression for DOMPurify prototype pollution, as it is used in testing only (Wiremock's bundled Swagger UI)
+        wiremock-jre8-standalone-2.35.2.jar: swagger-ui-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2024-45801, CVE-2024-47875
+        wiremock-jre8-standalone-2.35.2.jar: swagger-ui-es-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2024-45801, CVE-2024-47875
+        ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-45801</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppression for DOMPurify nesting-based mXSS, as it is used in testing only (Wiremock's bundled Swagger UI)
+        wiremock-jre8-standalone-2.35.2.jar: swagger-ui-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2024-45801, CVE-2024-47875
+        wiremock-jre8-standalone-2.35.2.jar: swagger-ui-es-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2024-45801, CVE-2024-47875
+        ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-47875</vulnerabilityName>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
Upgrade framework and dependencies for resolving vulnerabilities.

- upgrade Spring Boot to `3.3.5` (and Spring Framework `6.1.14`); (was `3.3.4` and `6.1.13`)
- upgrade Kotlin to `2.0.21` (was `2.0.20`)
- suppress vulnerabilities of DOMPurify (as not applicable, testing only)