### PR TITLE
[ESWE-858] Matching candidate job details distance calculation

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobMother.kt
@@ -290,7 +290,7 @@ class JobBuilder {
     return this
   }
 
-  fun withDistance(distance: Float): JobBuilder {
+  fun withDistanceInMiles(distance: Float): JobBuilder {
     this.distance = distance
     return this
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateJobDetailsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateJobDetailsGetShould.kt
@@ -18,14 +18,17 @@ class MatchingCandidateJobDetailsGetShould : MatchingCandidateJobDetailsTestCase
 
   @Test
   fun `retrieve details of a matching candidate job`() {
-    val release_area_postcode = "S3 7BS"
+    val releaseAreaPostcode = "S37BS"
+    val xCoordinate = 435169.9
+    val yCoordinate = 387721.29
+    osPlacesMockServer.stubGetAddressesForPostcode(releaseAreaPostcode, xCoordinate, yCoordinate)
 
     assertGetMatchingCandidateJobDetailsIsOK(
       id = tescoWarehouseHandler.id.id,
-      parameters = "prisonNumber=$prisonNumber&postcode=$release_area_postcode",
+      parameters = "prisonNumber=$prisonNumber&postcode=$releaseAreaPostcode",
       expectedResponse = builder()
         .from(tescoWarehouseHandler)
-        .withDistanceInMiles(4.1f)
+        .withDistanceInMiles(111.0f)
         .buildJobDetailsResponseBody(prisonNumber),
     )
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateJobDetailsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateJobDetailsGetShould.kt
@@ -18,12 +18,14 @@ class MatchingCandidateJobDetailsGetShould : MatchingCandidateJobDetailsTestCase
 
   @Test
   fun `retrieve details of a matching candidate job`() {
+    val release_area_postcode = "S3 7BS"
+
     assertGetMatchingCandidateJobDetailsIsOK(
       id = tescoWarehouseHandler.id.id,
-      parameters = "prisonNumber=$prisonNumber",
+      parameters = "prisonNumber=$prisonNumber&postcode=$release_area_postcode",
       expectedResponse = builder()
         .from(tescoWarehouseHandler)
-//        .withDistance(distanceInMiles)
+        .withDistanceInMiles(4.1f)
         .buildJobDetailsResponseBody(prisonNumber),
     )
   }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/shared/application/ApplicationTestCase.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/shared/application/ApplicationTestCase.kt
@@ -152,8 +152,8 @@ abstract class ApplicationTestCase {
     jobRepository.deleteAll()
     employerRepository.deleteAll()
     osPlacesMockServer.resetAll()
-    osPlacesMockServer.stubGetAddressesForPostcode("LS12")
-    osPlacesMockServer.stubGetAddressesForPostcode("NE157LR")
+    osPlacesMockServer.stubGetAddressesForPostcode("LS12", 426316.0, 432027.0)
+    osPlacesMockServer.stubGetAddressesForPostcode("NE157LR", 418788.0, 565604.0)
     whenever(timeProvider.now()).thenCallRealMethod()
     whenever(dateTimeProvider.now).thenReturn(Optional.of(defaultCurrentTime))
     countOfGettingCurrentTime[0] = 0

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/shared/infrastructure/OSPlacesMockServer.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/shared/infrastructure/OSPlacesMockServer.kt
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 private const val OS_PLACES_WIREMOCK_PORT = 8093
 
 class OSPlacesMockServer(private val apiKey: String) : WireMockServer(OS_PLACES_WIREMOCK_PORT) {
-  fun stubGetAddressesForPostcode(postcode: String) {
+  fun stubGetAddressesForPostcode(postcode: String, xCoordinate: Double? = 401024.0, yCoordinate: Double? = 154112.0) {
     val json = """{
       "header": {
         "uri": "https://api.os.uk/search/places/v1/postcode?postcode=$postcode",
@@ -35,8 +35,8 @@ class OSPlacesMockServer(private val apiKey: String) : WireMockServer(OS_PLACES_
             "POST_TOWN": "READING",
             "POSTCODE": "$postcode",
             "RPC": "1",
-            "X_COORDINATE": 401024.0,
-            "Y_COORDINATE": 154112.0,
+            "X_COORDINATE": $xCoordinate,
+            "Y_COORDINATE": $yCoordinate,
             "STATUS": "APPROVED",
             "LOGICAL_STATUS_CODE": "1",
             "CLASSIFICATION_CODE": "RD03",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -136,7 +136,7 @@ class JobsGet(
     @Parameter(description = "The release area’s postcode of the given prisoner")
     postcode: String?,
   ): ResponseEntity<GetMatchingCandidateJobResponse> {
-    val details = matchingCandidateJobDetailsRetriever.retrieve(id, prisonNumber)
+    val details = matchingCandidateJobDetailsRetriever.retrieve(id, prisonNumber, postcode)
     return when {
       details != null -> ResponseEntity.ok(details)
       else -> ResponseEntity.notFound().build()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobDetailsRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobDetailsRetriever.kt
@@ -9,14 +9,17 @@ import kotlin.jvm.optionals.getOrNull
 @Service
 class MatchingCandidateJobDetailsRetriever(
   private val matchingCandidateJobsRepository: MatchingCandidateJobRepository,
+  private val postcodeLocationService: PostcodeLocationService,
   private val jobRepository: JobRepository,
 ) {
-  fun retrieve(jobId: String, prisonNumber: String? = null): GetMatchingCandidateJobResponse? {
+  fun retrieve(jobId: String, prisonNumber: String? = null, releaseAreaPostcode: String? = null): GetMatchingCandidateJobResponse? {
+    releaseAreaPostcode?.let { postcodeLocationService.save(it) }
+
     return when {
       prisonNumber.isNullOrEmpty() -> jobRepository.findById(EntityId(jobId)).getOrNull()
         ?.let { job -> GetMatchingCandidateJobResponse.from(job) }
 
-      else -> matchingCandidateJobsRepository.findJobDetailsByPrisonNumber(jobId, prisonNumber).firstOrNull()
+      else -> matchingCandidateJobsRepository.findJobDetailsByPrisonNumberAndReleaseAreaPostcode(jobId, prisonNumber, releaseAreaPostcode).firstOrNull()
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -81,4 +81,49 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     @Param("jobId") jobId: String,
     @Param("prisonNumber") prisonNumber: String,
   ): List<GetMatchingCandidateJobResponse>
+
+  @Query(
+    """
+    SELECT new uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.GetMatchingCandidateJobResponse(
+      j.id.id,
+      j.employer.name,
+      j.title,
+      j.closingDate,
+      j.startDate,
+      j.postcode,
+      CAST(ROUND(SQRT(POWER(pos2.xCoordinate - pos1.xCoordinate, 2) + POWER(pos2.yCoordinate - pos1.yCoordinate, 2)) / 1609.34, 1) AS FLOAT),
+      j.sector,
+      j.salaryFrom,
+      j.salaryTo,
+      j.salaryPeriod,
+      j.additionalSalaryInformation,
+      j.workPattern,
+      j.hoursPerWeek,
+      j.contractType,
+      j.numberOfVacancies,
+      j.charityName,
+      j.isOnlyForPrisonLeavers,
+      j.offenceExclusions,
+      j.offenceExclusionsDetails, 
+      j.essentialCriteria,
+      j.desirableCriteria,
+      j.description,
+      j.howToApply,
+      CASE WHEN eoi.id IS NOT NULL THEN true ELSE false END,
+      CASE WHEN a.id IS NOT NULL THEN true ELSE false END,
+      j.createdAt
+    )
+    FROM Job j
+    LEFT JOIN j.expressionsOfInterest eoi on eoi.id.prisonNumber = :prisonNumber 
+    LEFT JOIN j.archived a on a.id.prisonNumber = :prisonNumber
+    LEFT JOIN Postcode pos1 on j.postcode = pos1.code
+    LEFT JOIN Postcode pos2 on pos2.code = :releaseAreaPostcode
+    WHERE j.id.id = :jobId
+    """,
+  )
+  fun findJobDetailsByPrisonNumberAndReleaseAreaPostcode(
+    @Param("jobId") jobId: String,
+    @Param("prisonNumber") prisonNumber: String,
+    @Param("releaseAreaPostcode") releaseAreaPostcode: String?,
+  ): List<GetMatchingCandidateJobResponse>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Postcode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Postcode.kt
@@ -16,10 +16,10 @@ data class Postcode(
   var code: String,
 
   @Column(name = "x_coordinate", nullable = true)
-  var xCoordinate: Float?,
+  var xCoordinate: Double?,
 
   @Column(name = "y_coordinate", nullable = true)
-  var yCoordinate: Float?,
+  var yCoordinate: Double?,
 ) : Auditable() {
   override fun toString(): String = """
     Postcode(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiDPA.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiDPA.kt
@@ -7,8 +7,8 @@ data class OsPlacesApiDPA(
   val postcode: String,
 
   @JsonProperty("X_COORDINATE")
-  val xCoordinate: Float?,
+  val xCoordinate: Double?,
 
   @JsonProperty("Y_COORDINATE")
-  val yCoordinate: Float?,
+  val yCoordinate: Double?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClient.kt
@@ -22,8 +22,8 @@ class OsPlacesApiWebClient(
 
     return searchResult?.results?.first()?.dpa ?: OsPlacesApiDPA(
       postcode = postcode,
-      xCoordinate = 0.00f,
-      yCoordinate = 0.00f,
+      xCoordinate = null,
+      yCoordinate = null,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobDetailsRetrieverShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobDetailsRetrieverShould.kt
@@ -23,8 +23,8 @@ class MatchingCandidateJobDetailsRetrieverShould : TestBase() {
   @InjectMocks
   private lateinit var matchingCandidateJobDetailsRetriever: MatchingCandidateJobDetailsRetriever
 
-  // private val expectedJobId = expectedJob.id
   private val expectedPrisonNumber = "A1234BC"
+  private val releaseAreaPostcode = "S37BS"
 
   @Test
   fun `return JobDetails without prisonNumber, when found`() {
@@ -45,14 +45,14 @@ class MatchingCandidateJobDetailsRetrieverShould : TestBase() {
   fun `return JobDetails with prisonNumber, when found`() {
     val job = amazonForkliftOperator.deepCopyMe()
     val expectedMatchingCandidateJobDetails = GetMatchingCandidateJobResponse.from(job, true, true)
-    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber))
+    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode))
       .thenReturn(listOf(expectedMatchingCandidateJobDetails))
 
     val actualMatchingCandidateJobDetails =
-      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
 
     verify(matchingCandidateJobsRepository, times(1))
-      .findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      .findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
     assertThat(actualMatchingCandidateJobDetails!!).usingRecursiveComparison()
       .isEqualTo(expectedMatchingCandidateJobDetails)
     assertThat(actualMatchingCandidateJobDetails.expressionOfInterest).isTrue()
@@ -64,14 +64,14 @@ class MatchingCandidateJobDetailsRetrieverShould : TestBase() {
     val job = amazonForkliftOperator.deepCopyMe()
     val expectedMatchingCandidateJobDetails =
       GetMatchingCandidateJobResponse.from(job = job, expressionOfInterest = true)
-    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber))
+    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode))
       .thenReturn(listOf(expectedMatchingCandidateJobDetails))
 
     val actualMatchingCandidateJobDetails =
-      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
 
     verify(matchingCandidateJobsRepository, times(1))
-      .findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      .findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
     assertThat(actualMatchingCandidateJobDetails!!.expressionOfInterest).isTrue()
     assertThat(actualMatchingCandidateJobDetails.archived).isFalse()
   }
@@ -80,14 +80,14 @@ class MatchingCandidateJobDetailsRetrieverShould : TestBase() {
   fun `return JobDetails with prisonNumber and Archived only, when found`() {
     val job = amazonForkliftOperator.deepCopyMe()
     val expectedMatchingCandidateJobDetails = GetMatchingCandidateJobResponse.from(job = job, archived = true)
-    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber))
+    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode))
       .thenReturn(listOf(expectedMatchingCandidateJobDetails))
 
     val actualMatchingCandidateJobDetails =
-      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
 
     verify(matchingCandidateJobsRepository, times(1))
-      .findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      .findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
     assertThat(actualMatchingCandidateJobDetails!!.expressionOfInterest).isFalse()
     assertThat(actualMatchingCandidateJobDetails.archived).isTrue()
   }
@@ -105,14 +105,14 @@ class MatchingCandidateJobDetailsRetrieverShould : TestBase() {
 
   @Test
   fun `return nothing with prisonNumber, when not found`() {
-    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber))
+    whenever(matchingCandidateJobsRepository.findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode))
       .thenReturn(listOf())
 
     val actualMatchingCandidateJobDetails =
-      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      matchingCandidateJobDetailsRetriever.retrieve(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
 
     verify(matchingCandidateJobsRepository, times(1))
-      .findJobDetailsByPrisonNumber(amazonForkliftOperator.id.id, expectedPrisonNumber)
+      .findJobDetailsByPrisonNumberAndReleaseAreaPostcode(amazonForkliftOperator.id.id, expectedPrisonNumber, releaseAreaPostcode)
     assertThat(actualMatchingCandidateJobDetails).isNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/PostcodeLocationServiceShould.kt
@@ -91,8 +91,8 @@ class PostcodeLocationServiceShould {
   private val expectedPostcode = Postcode(
     id = EntityId(postcodeId),
     code = amazonForkliftOperator.postcode,
-    xCoordinate = 1.23f,
-    yCoordinate = 4.56f,
+    xCoordinate = 1.23,
+    yCoordinate = 4.56,
   )
 
   private val expectedPostcodeWithNullCoordinates = Postcode(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClientShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClientShould.kt
@@ -39,8 +39,8 @@ class OsPlacesApiWebClientShould {
   fun `get coordinates when a valid postcode is provided`() {
     val expectedPostcode = OsPlacesApiDPA(
       postcode = amazonForkliftOperator.postcode,
-      xCoordinate = 1.23f,
-      yCoordinate = 4.56f,
+      xCoordinate = 1.23,
+      yCoordinate = 4.56,
     )
     val expectedSearchResult = OsPlacesApiResponse(
       results = listOf(


### PR DESCRIPTION
This PR aims to introduce the distance calculation between two locations identified by a postal code. We must first obtain the coordinates defining each postcode to do this calculation.

### Postcodes to coordinates

Each postcode has a pair of coordinates XY associated that defines its reference centre point. To obtain it, we use a third-party service, in our case [OS Places API](https://osdatahub.os.uk/docs/places/technicalSpecification)
The keys for use on our environments have been requested via the [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4/p1728314239141029) Slack channel.

The keys are stored on Kubernetes as secrets.

### Intermediate storage

One of the essential architectural decisions taken here is to store the postcodes and their coordinates in our database as a primitive cache. The main reasons were:
- If the third-party service is down, we can still provide calculations.
- If the postcode is already stored on the database, the request won't be done, saving time and resources.
- To manage calculations at a pagination level, we can improve its efficiency by moving that logic to the database query itself.

### Cache trade-offs:
Considering a simple cache implies some maintenance and decisions. For example, Royal Mail generates, modifies, deletes, and reuses postal codes monthly. But they get to the services every three months. We must assume that those coordinates we store have an expiration date and need to be refreshed occasionally. This is out of the scope of this PR, but that work must be planned to make this solution last without introducing errors. For now, the creation and update dates are stored for this purpose in the future.

### When we store the coordinates
Every time a Job is created or updated, the coordinates related to its postcode are retrieved and stored in the database. That makes updates an excellent tool to recover missing coordinates if something happens on creation.

<img width="1255" alt="image" src="https://github.com/user-attachments/assets/ffdb16e2-8ae0-44b3-9449-943e97e8cf57">

Whenever a search for a candidate matching list or detail is invoked, the release area postcode coordinates are retrieved and stored, being ready to calculate the distance.

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/1e52f577-df25-41ff-8d3d-59121137e15f">
