### PR TITLE
[ESWE-1106] Revise schedule of security scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ workflows:
   security:
     triggers:
       - schedule:
-          cron: "37 8 * * 1-5"
+          cron: "37 5 * * 1-5"
           filters:
             branches:
               only:


### PR DESCRIPTION
run `security` scans earlier to avoid peak hours, which may result in errors like `TOOMANYREQUESTS` while downloading vulnerability DB