### PR TITLE
[ESWE-865] Updates candidate matching query parameter

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -49,7 +49,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
     @Test
     fun `return a default paginated matching candidate Jobs list`() {
       assertGetMatchingCandidateJobsIsOK(
-        parameters = "prisonNumber=$prisonNumber&location=$releaseAreaPostcode",
+        parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode",
         expectedResponse = expectedResponseListOf(
           abcConstructionApprentice.candidateMatchingItemListResponseBody,
           amazonForkliftOperator.candidateMatchingItemListResponseBody,
@@ -68,7 +68,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
         assertAddArchived(tescoWarehouseHandler.id.id, anotherPrisonNumber)
 
         assertGetMatchingCandidateJobsIsOK(
-          parameters = "prisonNumber=$prisonNumber&location=$releaseAreaPostcode",
+          parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode",
           expectedResponse = expectedResponseListOf(
             tescoWarehouseHandler.candidateMatchingItemListResponseBody,
             abcConstructionApprentice.candidateMatchingItemListResponseBody,
@@ -87,7 +87,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
         assertAddExpressionOfInterest(tescoWarehouseHandler.id.id, anotherPrisonNumber)
 
         assertGetMatchingCandidateJobsIsOK(
-          parameters = "prisonNumber=$prisonNumber&location=$releaseAreaPostcode",
+          parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode",
           expectedResponse = expectedResponseListOf(
             tescoWarehouseHandler.candidateMatchingItemListResponseBody,
             amazonForkliftOperator.candidateMatchingItemListResponseBody,
@@ -104,7 +104,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       @Test
       fun `return a custom paginated matching candidate Jobs list`() {
         assertGetMatchingCandidateJobsIsOK(
-          parameters = "prisonNumber=$prisonNumber&location=$releaseAreaPostcode&page=1&size=1",
+          parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode&page=1&size=1",
           expectedResponse = expectedResponseListOf(
             size = 1,
             page = 1,
@@ -121,7 +121,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       @Test
       fun `return Jobs filtered by job sector`() {
         assertGetMatchingCandidateJobsIsOK(
-          parameters = "prisonNumber=$prisonNumber&location=$releaseAreaPostcode&sectors=retail",
+          parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode&sectors=retail",
           expectedResponse = expectedResponseListOf(
             amazonForkliftOperator.candidateMatchingItemListResponseBody,
           ),
@@ -131,7 +131,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       @Test
       fun `return Jobs filtered by various job sectors`() {
         assertGetMatchingCandidateJobsIsOK(
-          parameters = "prisonNumber=$prisonNumber&location=$releaseAreaPostcode&sectors=retail,warehousing",
+          parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode&sectors=retail,warehousing",
           expectedResponse = expectedResponseListOf(
             tescoWarehouseHandler.candidateMatchingItemListResponseBody,
             amazonForkliftOperator.candidateMatchingItemListResponseBody,
@@ -146,7 +146,7 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       @Test
       fun `return Jobs list sorted by job title, in ascending order`() {
         assertGetMatchingCandidateJobsIsOKAndSortedByJobTitle(
-          parameters = "prisonNumber=$prisonNumber&location=$releaseAreaPostcode&sortBy=jobTitle&sortOrder=asc",
+          parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode&sortBy=jobTitle&sortOrder=asc",
           expectedJobTitlesSorted = listOf(
             "Apprentice plasterer",
             "Forklift operator",

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateJobDetailsGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateJobDetailsGetShould.kt
@@ -20,7 +20,7 @@ class MatchingCandidateJobDetailsGetShould : MatchingCandidateJobDetailsTestCase
   fun `retrieve details of a matching candidate job`() {
     assertGetMatchingCandidateJobDetailsIsOK(
       id = tescoWarehouseHandler.id.id,
-      parameters = "prisonNumber=$prisonNumber&postcode=$releaseAreaPostcode",
+      parameters = "prisonNumber=$prisonNumber&releaseArea=$releaseAreaPostcode",
       expectedResponse = builder()
         .from(tescoWarehouseHandler)
         .withDistanceInMiles(1.0f)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -82,9 +82,9 @@ class JobsGet(
     @RequestParam(required = false)
     sectors: List<String>? = null,
     @RequestParam(required = false)
-    location: String? = null,
+    releaseArea: String? = null,
     @RequestParam(required = false)
-    distance: Float? = null,
+    searchRadius: Float? = null,
     @RequestParam(defaultValue = "title", required = false)
     sortBy: String?,
     @RequestParam(defaultValue = "asc", required = false)
@@ -101,7 +101,7 @@ class JobsGet(
     val lowerCaseSectors = sectors?.map { it.lowercase() }
     val direction = if (sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
     val pageable: Pageable = PageRequest.of(page, size, Sort.by(direction, sortedBy))
-    val jobList = matchingCandidateJobRetriever.retrieveAllJobs(prisonNumber, lowerCaseSectors, location, distance, pageable)
+    val jobList = matchingCandidateJobRetriever.retrieveAllJobs(prisonNumber, lowerCaseSectors, releaseArea, searchRadius, pageable)
     return ResponseEntity.ok(jobList)
   }
 
@@ -141,9 +141,9 @@ class JobsGet(
     prisonNumber: String?,
     @RequestParam(required = false)
     @Parameter(description = "The release area’s postcode of the given prisoner")
-    postcode: String?,
+    releaseArea: String?,
   ): ResponseEntity<GetMatchingCandidateJobResponse> {
-    val details = matchingCandidateJobDetailsRetriever.retrieve(id, prisonNumber, postcode)
+    val details = matchingCandidateJobDetailsRetriever.retrieve(id, prisonNumber, releaseArea)
     return when {
       details != null -> ResponseEntity.ok(details)
       else -> ResponseEntity.notFound().build()


### PR DESCRIPTION
This PR updates the Candidate Matching query parameter for the Release Area Postcode. To make our API more cohesive, we are making all parameters that refer to the same concept to be called equally.

So now bot `location` and `postcode` parameters are now replaced by `releaseArea`