### PR TITLE
[ESWE-867] Fixes of matching/matched/closing jobs and postcodes

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodeMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/PostcodeMother.kt
@@ -6,7 +6,9 @@ object PostcodeMother {
   val postcodeMap = listOf(
     postcode("LS12", 428877.0, 432882.0),
     postcode("NE157LR", 418688.0, 565599.0),
+    postcode("NE15 7LR", 418688.0, 565599.0),
     postcode("LS110AN", 429017.0, 431869.0),
+    postcode("LS11 0AN", 429017.0, 431869.0),
     postcode("M4 5BD", 385003.00, 398558.00),
     postcode("NW1 6XE", 527870.40, 182081.17),
     postcode("NG1 1AA", 457804.00, 340087.00),

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
@@ -229,7 +229,7 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
       inner class AndReleaseArea {
         private lateinit var expectedJobs: List<Job>
         private lateinit var expectedResults: List<GetMatchingCandidateJobsResponse>
-        private val releaseArea = "LS110AN"
+        private val releaseArea = "LS11 0AN"
 
         @BeforeEach
         fun setUp() {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
@@ -262,7 +262,7 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
             tescoWarehouseHandler.listResponse(true, 83.3f),
           )
           val sort = CALC_DISTANCE_EXPRESSION.let {
-            JpaSort.unsafe(Sort.Direction.ASC, it)
+            JpaSort.unsafe(Sort.Direction.ASC, it, "title")
           }
           val pageableSortByDistance = PageRequest.of(0, 20, sort)
           assertFindJobsOfInterestIsExpected(

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
@@ -75,7 +75,7 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
 
     @BeforeEach
     fun setUp() {
-      allJobs.toTypedArray().let { givenJobsHaveBeenCreated(*it) }
+      givenJobsHaveBeenCreated(*allJobs.toTypedArray())
     }
 
     @Test

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
@@ -40,9 +40,10 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
   private val prisonNumber = "A1234BC"
   private val anotherPrisonNumber = "X9876YZ"
 
-  private val defaultPageable = PageRequest.of(0, 10)
-  private val closingSoonPageable = PageRequest.of(0, 3)
-  private val paginatedSortByClosingDateAsc = PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "closingDate", "title"))
+  private val defaultSort = Sort.by(Sort.Direction.ASC, "closingDate", "title")
+  private val defaultPageable = PageRequest.of(0, 10, defaultSort)
+  private val closingSoonPageable = PageRequest.of(0, 3, defaultSort)
+  private val paginatedSortByClosingDateAsc = PageRequest.of(0, 20, defaultSort)
   private val today = LocalDate.now()
 
   @Nested
@@ -115,6 +116,7 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
         val expectedJobs = listOf(tescoWarehouseHandler, abcConstructionApprentice)
         assertFindAllJobsIsExpected(
           currentDate = today,
+          pageable = paginatedSortByClosingDateAsc,
           expectedSize = expectedJobs.size,
           expectedJobs = expectedJobs,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
@@ -16,9 +16,11 @@ class MatchingCandidateJobRetriever(
   private val matchingCandidateJobsRepository: MatchingCandidateJobRepository,
   private val postcodeLocationService: PostcodeLocationService,
 ) {
+  private val today: LocalDate get() = LocalDate.now()
+
   fun retrieveAllJobs(prisonNumber: String, sectors: List<String>?, location: String?, distance: Float?, pageable: Pageable): Page<GetMatchingCandidateJobsResponse> {
     location?.let { postcodeLocationService.save(it) }
-    return matchingCandidateJobsRepository.findAll(prisonNumber, sectors, location, pageable)
+    return matchingCandidateJobsRepository.findAll(prisonNumber, sectors, location, today, pageable)
   }
 
   fun retrieveClosingJobs(prisonNumber: String, sectors: List<String>?, size: Int): List<GetJobsClosingSoonResponse> {
@@ -26,14 +28,14 @@ class MatchingCandidateJobRetriever(
       matchingCandidateJobsRepository.findJobsClosingSoon(
         prisonNumber = prisonNumber,
         sectors = sectors?.map { it.lowercase() },
-        currentDate = LocalDate.now(),
+        currentDate = today,
         pageable = limitedBySize,
       )
     }
   }
 
   fun retrieveClosingJobsOfInterest(prisonNumber: String): List<GetJobsClosingSoonResponse> {
-    return matchingCandidateJobsRepository.findJobsOfInterestClosingSoon(prisonNumber, LocalDate.now())
+    return matchingCandidateJobsRepository.findJobsOfInterestClosingSoon(prisonNumber, today)
   }
 
   fun retrieveJobsOfInterest(
@@ -45,7 +47,7 @@ class MatchingCandidateJobRetriever(
     return matchingCandidateJobsRepository.findJobsOfInterest(
       prisonNumber = prisonNumber,
       releaseAreaPostcode = releaseAreaPostcode,
-      currentDate = LocalDate.now(),
+      currentDate = today,
       pageable = pageable,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -36,7 +36,8 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     LEFT JOIN Archived a ON a.job.id.id = j.id.id AND a.id.prisonNumber = :prisonNumber
     LEFT JOIN Postcode pos1 ON j.postcode = pos1.code
     LEFT JOIN Postcode pos2 ON pos2.code = :location
-    WHERE (:sectors IS NULL OR LOWER(j.sector) IN :sectors)
+    WHERE  (j.closingDate >= :currentDate OR j.closingDate IS NULL)
+    AND (LOWER(j.sector) IN :sectors OR :sectors IS NULL )
     AND a.id IS NULL
   """,
   )
@@ -44,6 +45,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     @Param("prisonNumber") prisonNumber: String,
     @Param("sectors") sectors: List<String>?,
     @Param("location") location: String? = null,
+    @Param("currentDate") currentDate: LocalDate,
     pageable: Pageable,
   ): Page<GetMatchingCandidateJobsResponse>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Postcode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Postcode.kt
@@ -12,7 +12,7 @@ data class Postcode(
   @Id
   var id: EntityId,
 
-  @Column(name = "code", length = 7, nullable = false)
+  @Column(name = "code", length = 8, nullable = false)
   var code: String,
 
   @Column(name = "x_coordinate", nullable = true)


### PR DESCRIPTION
This PR contains a few fixes

1. `Postcode` length to 8 (from 7)
2. `closingDate` check is added to matched job
3.  Default sorts have been added to improve test results' stability.