### PR TITLE
[ESWE-865] Matching candidate unexpected error returns fallback postcode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   }
   testImplementation("org.testcontainers:postgresql")
   testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("io.github.hakky54:logcaptor:2.9.3")
 
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClient.kt
@@ -18,18 +18,26 @@ class OsPlacesApiWebClient(
     val uri = "/postcode?postcode=$postcode&key=${osPlacesAPIProperties.key}"
     log.debug("Calling operation for $uri")
 
-    val searchResult = osPlacesWebClient
-      .get()
-      .uri(uri)
-      .accept(APPLICATION_JSON)
-      .retrieve()
-      .bodyToMono(OsPlacesApiResponse::class.java)
-      .block()
+    return try {
+      val searchResult = osPlacesWebClient
+        .get()
+        .uri(uri)
+        .accept(APPLICATION_JSON)
+        .retrieve()
+        .bodyToMono(OsPlacesApiResponse::class.java)
+        .block()
 
-    return searchResult?.results?.first()?.dpa ?: OsPlacesApiDPA(
-      postcode = postcode,
-      xCoordinate = null,
-      yCoordinate = null,
-    )
+      searchResult?.results?.first()?.dpa ?: OsPlacesApiDPA(
+        postcode = postcode,
+        xCoordinate = null,
+        yCoordinate = null,
+      )
+    } catch (exception: Exception) {
+      OsPlacesApiDPA(
+        postcode = postcode,
+        xCoordinate = null,
+        yCoordinate = null,
+      )
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClient.kt
@@ -33,6 +33,7 @@ class OsPlacesApiWebClient(
         yCoordinate = null,
       )
     } catch (exception: Exception) {
+      log.error("Unexpected error while calling OS Places API for postcode: $postcode", exception)
       OsPlacesApiDPA(
         postcode = postcode,
         xCoordinate = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClientShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClientShould.kt
@@ -71,23 +71,22 @@ class OsPlacesApiWebClientShould {
 
   @Test
   fun `return a fallback object when unexpected error calling OS Places API`() {
-    val postcode = "INVALID"
     val body = ByteArray(0)
     val charset = null
     val responseException = WebClientResponseException
-      .create(404, "Bad Request", EMPTY, body, charset)
+      .create(401, "Unauthorized", EMPTY, body, charset)
 
     val requestUriMock = mock(WebClient.RequestHeadersUriSpec::class.java)
     val requestHeadersMock = mock(WebClient.RequestHeadersSpec::class.java)
     whenever(osPlacesWebClient.get()).thenReturn(requestUriMock)
-    whenever(requestUriMock.uri("/postcode?postcode=$postcode&key=test-api-key"))
+    whenever(requestUriMock.uri("/postcode?postcode=${amazonForkliftOperator.postcode}&key=$API_KEY"))
       .thenReturn(requestHeadersMock)
     whenever(requestHeadersMock.accept(APPLICATION_JSON)).thenReturn(requestHeadersMock)
     whenever(requestHeadersMock.retrieve()).thenThrow(responseException)
 
-    val result = osPlacesAPIWebClient.getAddressesFor(postcode)
+    val result = osPlacesAPIWebClient.getAddressesFor(amazonForkliftOperator.postcode)
 
-    assertEquals(postcode, result.postcode)
+    assertEquals(amazonForkliftOperator.postcode, result.postcode)
     assertNull(result.xCoordinate)
     assertNull(result.yCoordinate)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClientShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/OsPlacesApiWebClientShould.kt
@@ -123,15 +123,14 @@ class OsPlacesApiWebClientShould {
         logEvent.throwable.isPresent
         logEvent.throwable.get().message!!.contains(responseException.message.toString())
       },
-      "Expected error log to contain the expected exception message: ${responseException.message}"
+      "Expected error log to contain the expected exception message: ${responseException.message}",
     )
 
     assertTrue(
       logCaptor.errorLogs.any { log ->
         log.contains("Unexpected error while calling OS Places API for postcode: ${amazonForkliftOperator.postcode}")
       },
-      "Expected error log when unexpected error calling OS Places API not found"
+      "Expected error log when unexpected error calling OS Places API not found",
     )
-
   }
 }


### PR DESCRIPTION
This PR:
- Assures that a fallback object with the original postcode and null coordinates is returned in case of any problem calling the OS Places API or processing the response.
- It now adds log messages to enable future debug and specific error handling. The tests expect the exception message to be logged as part of the error message.