### PR TITLE
[ESWE-1129] Suppress vulnerability of test-only dependency

### DIFF
--- a/jobs-board-suppressions.xml
+++ b/jobs-board-suppressions.xml
@@ -19,4 +19,14 @@
         <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
         <vulnerabilityName>CVE-2024-47875</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppression for DOMPurify Prototype Pollution, as it is used in testing only (Wiremock's bundled Swagger UI)
+        wiremock-jre8-standalone-2.35.1.jar: swagger-ui-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2024-48910
+        wiremock-jre8-standalone-2.35.1.jar: swagger-ui-es-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2024-48910
+        ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-48910</vulnerabilityName>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
suppress CVE-2024-48910 via test-only dependency Wiremock bundle