### PR TITLE
[ESWE-1137] 'No fixed abode' release area postcode and any Search Radius should return Job list

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.amaz
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.builder
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.candidateMatchingListItemResponseBody
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.JobMother.tescoWarehouseHandler
+import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.PostcodeMother.NO_FIXED_ABODE_POSTCODE
 import uk.gov.justice.digital.hmpps.jobsboard.api.controller.jobs.PostcodeMother.RELEASE_AREA_POSTCODE
 
 @DisplayName("Matching Candidate GET Should")
@@ -58,8 +59,63 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
     }
 
     @Nested
-    @DisplayName("And a release area postcode has been provided")
-    inner class AndReleaseAreaHasBeenProvided {
+    @DisplayName("And a 'no fixed abode' release area postcode has been provided")
+    inner class AndNoFixedAbodeReleaseAreaPostcodeHasBeenProvided {
+      @BeforeEach
+      fun setUp() {
+        requestParams.append("&releaseArea=$NO_FIXED_ABODE_POSTCODE")
+      }
+
+      @Test
+      fun `return Jobs list without calculating distance`() {
+        assertGetMatchingCandidateJobsIsOK(
+          parameters = requestParams.toString(),
+          expectedResponse = expectedResponseListOf(
+            builder().from(abcConstructionApprentice)
+              .withDistanceInMiles(null)
+              .buildCandidateMatchingListItemResponseBody(),
+            builder().from(amazonForkliftOperator)
+              .withDistanceInMiles(null)
+              .buildCandidateMatchingListItemResponseBody(),
+            builder().from(tescoWarehouseHandler)
+              .withDistanceInMiles(null)
+              .buildCandidateMatchingListItemResponseBody(),
+          ),
+        )
+      }
+
+      @Nested
+      @DisplayName("And a search radius has been provided")
+      inner class AndSearchRadiusHasBeenProvided {
+        @BeforeEach
+        fun setUp() {
+          val searchRadiusInMiles = 20
+          requestParams.append("&searchRadius=$searchRadiusInMiles")
+        }
+
+        @Test
+        fun `return Jobs list without calculating distance`() {
+          assertGetMatchingCandidateJobsIsOK(
+            parameters = requestParams.toString(),
+            expectedResponse = expectedResponseListOf(
+              builder().from(abcConstructionApprentice)
+                .withDistanceInMiles(null)
+                .buildCandidateMatchingListItemResponseBody(),
+              builder().from(amazonForkliftOperator)
+                .withDistanceInMiles(null)
+                .buildCandidateMatchingListItemResponseBody(),
+              builder().from(tescoWarehouseHandler)
+                .withDistanceInMiles(null)
+                .buildCandidateMatchingListItemResponseBody(),
+            ),
+          )
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("And a regular valid release area postcode has been provided")
+    inner class AndReleaseAreaPostcodeHasBeenProvided {
       @BeforeEach
       fun setUp() {
         requestParams.append("&releaseArea=$RELEASE_AREA_POSTCODE")

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/PostcodeMother.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/PostcodeMother.kt
@@ -10,6 +10,7 @@ import java.util.UUID.randomUUID
 object PostcodeMother {
 
   const val RELEASE_AREA_POSTCODE = "AG121RW"
+  const val NO_FIXED_ABODE_POSTCODE = "NF1 1NF"
 
   val postcodeMap = listOf(
     postcode(RELEASE_AREA_POSTCODE, 0.0, 0.0),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -40,7 +40,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     AND (LOWER(j.sector) IN :sectors OR :sectors IS NULL )
     AND a.id IS NULL
     AND (CAST(ROUND(SQRT(POWER(pos2.xCoordinate - pos1.xCoordinate, 2) + POWER(pos2.yCoordinate - pos1.yCoordinate, 2)) / 1609.34, 1) AS FLOAT) <= :searchRadius
-    OR pos1.code IS NULL OR pos2.code IS NULL OR :searchRadius IS NULL)
+    OR pos1.code IS NULL OR pos2.code IS NULL OR pos2.xCoordinate IS NULL OR pos2.yCoordinate IS NULL OR :searchRadius IS NULL)
   """,
   )
   fun findAll(


### PR DESCRIPTION
This PR fixes an unwanted behaviour on the backend Matching Candidates endpoint for prisoners with a special 'No fixed abode' release area postcode (NF1 1NF) assigned and any Search Radius provided. With these two values passed, the result will always be an empty list. It's interesting to note that if Search Radius is not provided, the list is generated correctly.

In summary, when a postcode has no associated coordinates for any reason, the Search Radius filter must be avoided and should not affect the filtering process.

This PR solves this behaviour by also checking that the coordinates related to the release area are not null.