### PR TITLE
[ESWE-1258] Upgrade dependencies; Add suppression; workaround for JPA issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,20 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.1"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.3"
   kotlin("plugin.spring") version "2.1.10"
   kotlin("plugin.jpa") version "2.1.10"
   id("jvm-test-suite")
   id("jacoco")
 }
 
-ext["logback.version"] = "1.5.16"
-
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.3.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.3.2")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.data:spring-data-envers")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5") {
+    implementation("org.webjars:swagger-ui:5.20.0")
+  }
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
   runtimeOnly("org.postgresql:postgresql")
 

--- a/jobs-board-suppressions.xml
+++ b/jobs-board-suppressions.xml
@@ -28,5 +28,13 @@
         <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
         <vulnerabilityName>CVE-2024-48910</vulnerabilityName>
     </suppress>
-
+    <suppress>
+        <notes><![CDATA[
+        Suppression for DOMPurify mXSS, as it is used in testing only (Wiremock's bundled Swagger UI)
+        wiremock-jre8-standalone-2.35.1.jar: swagger-ui-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2025-26791
+        wiremock-jre8-standalone-2.35.1.jar: swagger-ui-es-bundle.js (pkg:javascript/DOMPurify@2.3.3) : CVE-2025-26791
+        ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>CVE-2025-26791</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -37,7 +37,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     LEFT JOIN Postcode pos1 ON j.postcode = pos1.code
     LEFT JOIN Postcode pos2 ON pos2.code = :releaseArea
     WHERE  (j.closingDate >= :currentDate OR j.closingDate IS NULL)
-    AND (LOWER(j.sector) IN :sectors OR :sectors IS NULL )
+    AND (LOWER(j.sector) IN :#{#sectors} OR :#{#sectors} IS NULL )
     AND a.id IS NULL
     AND (CAST(ROUND(SQRT(POWER(pos2.xCoordinate - pos1.xCoordinate, 2) + POWER(pos2.yCoordinate - pos1.yCoordinate, 2)) / 1609.34, 1) AS FLOAT) <= :searchRadius
     OR pos1.code IS NULL OR pos2.code IS NULL OR pos2.xCoordinate IS NULL OR pos2.yCoordinate IS NULL OR :searchRadius IS NULL)


### PR DESCRIPTION
- upgrade gradle-spring-boot plugin (`7.1.3`, with Spring Boot to `3.4.3`)
- upgrade `swagger-ui` to `5.20.0`
- upgrade sqs lib to `5.3.2`
- upgrade `springdoc-openapi-starter-webmvc-ui` to `2.8.5`
- suppress for `wiremock-standalone`
- workaround JPA bug (of `3.4.3`) 


workaround taken from https://github.com/spring-projects/spring-data-jpa/issues/3784