### PR TITLE
[ESWE-1738]: should filter (exclude) matched jobs by offence exclusions.

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -696,4 +696,31 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       )
     }
   }
+
+  @Nested
+  @DisplayName("Given request has offenceExclusion parameters")
+  inner class GivenRequestHasOffenceExclusionParameters {
+
+    @BeforeEach
+    fun beforeEach() = givenRegionalAndNationalJobsAreCreated()
+
+    @Test
+    fun `returns filtered out jobs with matching offence exclusion`() {
+      requestParams.append("&offenceExclusions=DRIVING")
+      assertGetMatchingCandidateJobsIsOK(
+        parameters = requestParams.toString(),
+        expectedResponse = expectedResponseListOf(10,0,
+          builder().from(tescoWarehouseHandler)
+            .withDistanceInMiles(null)
+            .buildCandidateMatchingListItemResponseBody(),
+          builder().from(abcConstructionApprentice)
+            .withDistanceInMiles(null)
+            .buildCandidateMatchingListItemResponseBody(),
+          builder().from(asdaWarehouseHandlerNonGeoCoded)
+            .withDistanceInMiles(null)
+            .buildCandidateMatchingListItemResponseBody(),
+        ),
+      )
+    }
+  }
 }

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -709,7 +709,9 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
       requestParams.append("&offenceExclusions=DRIVING")
       assertGetMatchingCandidateJobsIsOK(
         parameters = requestParams.toString(),
-        expectedResponse = expectedResponseListOf(10,0,
+        expectedResponse = expectedResponseListOf(
+          10,
+          0,
           builder().from(tescoWarehouseHandler)
             .withDistanceInMiles(null)
             .buildCandidateMatchingListItemResponseBody(),

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
@@ -600,6 +600,7 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
     postcode = postcode,
     isNational = isNational,
     closingDate = closingDate,
+    offenceExclusions = offenceExclusions,
     hasExpressedInterest = hasExpressedInterest,
     createdAt = createdAt,
     distance = distance,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -154,6 +154,8 @@ class JobsGet(
     isNationalJob: Boolean,
     @RequestParam(required = false)
     employerId: String?,
+    @RequestParam(required = false)
+    offenceExclusions: List<String>? = null,
   ): ResponseEntity<Page<GetMatchingCandidateJobsResponse>> {
     val direction = if (sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
     val sortedBy = when (sortBy) {
@@ -163,7 +165,7 @@ class JobsGet(
     }
     val lowerCaseSectors = sectors?.map { it.lowercase() }
     val pageable: Pageable = PageRequest.of(page, size, sortedBy)
-    val jobList = matchingCandidateJobRetriever.retrieveAllJobs(prisonNumber, lowerCaseSectors, releaseArea, searchRadius, pageable, isNationalJob, employerId)
+    val jobList = matchingCandidateJobRetriever.retrieveAllJobs(prisonNumber, lowerCaseSectors, releaseArea, searchRadius, pageable, isNationalJob, employerId, offenceExclusions)
     return ResponseEntity.ok(jobList)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetMatchingCandidateJobsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetMatchingCandidateJobsResponse.kt
@@ -10,6 +10,7 @@ data class GetMatchingCandidateJobsResponse(
   val sector: String,
   val postcode: String? = null,
   val closingDate: LocalDate? = null,
+  val offenceExclusions: String,
   val hasExpressedInterest: Boolean = false,
   val createdAt: Instant? = null,
   val distance: Float?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -28,6 +29,7 @@ class MatchingCandidateJobRetriever(
     pageable: Pageable,
     isNationalJob: Boolean? = false,
     employerId: String?,
+    offenceExclusions: List<String>?,
   ): Page<GetMatchingCandidateJobsResponse> {
     releaseArea?.let { postcodeLocationService.save(it) }
     var maybeRevisedSearchRadiusInput = searchRadius
@@ -38,7 +40,34 @@ class MatchingCandidateJobRetriever(
       maybeRevisedReleaseAreaInput = null
     }
 
-    return matchingCandidateJobsRepository.findAll(prisonNumber, sectors, maybeRevisedReleaseAreaInput, maybeRevisedSearchRadiusInput, today, isNationalJob, employerId, pageable)
+    val matchingJobs = matchingCandidateJobsRepository.findAll(
+      prisonNumber,
+      sectors,
+      maybeRevisedReleaseAreaInput,
+      maybeRevisedSearchRadiusInput,
+      today,
+      isNationalJob,
+      employerId,
+      pageable,
+    )
+
+    // Apply filtering if offenceExclusions is provided
+    if (!offenceExclusions.isNullOrEmpty()) {
+      val candidateExclusions = offenceExclusions.map { it.uppercase().trim() }.toSet()
+
+      val filteredContent = matchingJobs.content.filter { job ->
+        val jobExclusions = job.offenceExclusions
+          ?.split(",")
+          ?.map { it.uppercase().trim() }
+          ?.toSet() ?: emptySet()
+
+        jobExclusions.none { it in candidateExclusions }
+      }
+
+      return PageImpl(filteredContent, pageable, matchingJobs.totalElements)
+    }
+
+    return matchingJobs
   }
 
   fun retrieveClosingJobs(prisonNumber: String, sectors: List<String>?, size: Int): List<GetJobsClosingSoonResponse> = PageRequest.of(0, size).let { limitedBySize ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
@@ -55,7 +55,7 @@ class MatchingCandidateJobRetriever(
     if (!offenceExclusions.isNullOrEmpty()) {
       val candidateExclusions = offenceExclusions.map { it.uppercase().trim() }.toSet()
 
-      val filteredContent = matchingJobs.content.filter { job ->
+      val filteredContent : List<GetMatchingCandidateJobsResponse> = matchingJobs.content.filter { job ->
         val jobExclusions = job.offenceExclusions
           ?.split(",")
           ?.map { it.uppercase().trim() }
@@ -64,7 +64,7 @@ class MatchingCandidateJobRetriever(
         jobExclusions.none { it in candidateExclusions }
       }
 
-      return PageImpl(filteredContent, pageable, matchingJobs.totalElements)
+      return PageImpl(filteredContent, pageable, filteredContent.size.toLong())
     }
 
     return matchingJobs

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
@@ -55,7 +55,7 @@ class MatchingCandidateJobRetriever(
     if (!offenceExclusions.isNullOrEmpty()) {
       val candidateExclusions = offenceExclusions.map { it.uppercase().trim() }.toSet()
 
-      val filteredContent : List<GetMatchingCandidateJobsResponse> = matchingJobs.content.filter { job ->
+      val filteredContent: List<GetMatchingCandidateJobsResponse> = matchingJobs.content.filter { job ->
         val jobExclusions = job.offenceExclusions
           ?.split(",")
           ?.map { it.uppercase().trim() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -26,6 +26,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
       j.sector,
       j.postcode,
       j.closingDate,
+      j.offenceExclusions,
       CASE WHEN eoi.createdAt IS NOT NULL THEN true ELSE false END,
       j.createdAt,
       CASE WHEN pos1.xCoordinate IS NULL OR pos1.yCoordinate IS NULL
@@ -225,6 +226,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
       j.sector,
       j.postcode,
       j.closingDate,
+      j.offenceExclusions,
       CASE WHEN eoi.createdAt IS NOT NULL THEN true ELSE false END,
       j.createdAt,
       $CALC_DISTANCE_EXPRESSION,
@@ -257,6 +259,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
       j.sector,
       j.postcode,
       j.closingDate,
+      j.offenceExclusions,
       CASE WHEN eoi.createdAt IS NOT NULL THEN true ELSE false END,
       j.createdAt,
       $CALC_DISTANCE_EXPRESSION,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetrieverShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetrieverShould.kt
@@ -1,0 +1,156 @@
+package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.MatchingCandidateJobRepository
+import java.time.Instant
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class MatchingCandidateJobRetrieverShould : TestBase() {
+
+  @Mock
+  private lateinit var matchingCandidateJobsRepository: MatchingCandidateJobRepository
+
+  @InjectMocks
+  private lateinit var matchingCandidateJobRetriever: MatchingCandidateJobRetriever
+
+  private val today = LocalDate.now()
+  private val prisonNumber = "A1234BC"
+  private val pageable = PageRequest.of(0, 10)
+
+  @BeforeEach
+  fun setUp() {
+    whenever(timeProvider.today()).thenReturn(today)
+  }
+
+  @Test
+  fun `retrieveAllJobs should filter out jobs matching candidate offence exclusions`() {
+    // Given
+    val offenceExclusions = listOf("ARSON", "DRIVING")
+
+    val job1 = createJobResponse(id = "1", exclusions = "NONE")
+    val job2 = createJobResponse(id = "2", exclusions = "ARSON, OTHER") // Contains ARSON
+    val job3 = createJobResponse(id = "3", exclusions = "DRIVING") // Contains DRIVING
+    val job4 = createJobResponse(id = "4", exclusions = "CASE_BY_CASE")
+
+    val dbPage = PageImpl(listOf(job1, job2, job3, job4), pageable, 4)
+
+    whenever(
+      matchingCandidateJobsRepository.findAll(
+        prisonNumber = eq(prisonNumber),
+        sectors = anyOrNull(),
+        releaseArea = anyOrNull(),
+        searchRadius = anyOrNull(),
+        currentDate = eq(today),
+        isNationalJob = anyOrNull(),
+        employerId = anyOrNull(),
+        pageable = eq(pageable),
+      ),
+    ).thenReturn(dbPage)
+
+    // When
+    val result = matchingCandidateJobRetriever.retrieveAllJobs(
+      prisonNumber = prisonNumber,
+      sectors = listOf("CONSTRUCTION"),
+      releaseArea = "S1 1AA",
+      searchRadius = 5,
+      pageable = pageable,
+      isNationalJob = false,
+      employerId = "emp-123",
+      offenceExclusions = offenceExclusions,
+    )
+
+    // Then
+    // Only Job 1 and Job 4 remain
+    assertThat(result.content).hasSize(2)
+    assertThat(result.content.map { it.id }).containsExactly("1", "4")
+
+    verify(matchingCandidateJobsRepository, times(1)).findAll(
+      eq(prisonNumber),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
+      eq(today),
+      anyOrNull(),
+      anyOrNull(),
+      eq(pageable),
+    )
+  }
+
+  @Test
+  fun `retrieveAllJobs should be case insensitive and handle whitespace when filtering`() {
+    // Given
+    val offenceExclusions = listOf(" arson ") // Lowercase with space
+    val job = createJobResponse(id = "1", exclusions = "  ARSON  ") // Uppercase with space
+
+    whenever(matchingCandidateJobsRepository.findAll(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
+      .thenReturn(PageImpl(listOf(job)))
+
+    // When
+    val result = matchingCandidateJobRetriever.retrieveAllJobs(
+      prisonNumber = prisonNumber,
+      sectors = null,
+      releaseArea = null,
+      searchRadius = null,
+      pageable = pageable,
+      offenceExclusions = offenceExclusions,
+      employerId = null,
+    )
+
+    // Then
+    assertThat(result.content).isEmpty()
+  }
+
+  @Test
+  fun `retrieveAllJobs should return original page if offenceExclusions is empty`() {
+    // Given
+    val job = createJobResponse(id = "1", exclusions = "ARSON")
+    val dbPage = PageImpl(listOf(job))
+
+    whenever(matchingCandidateJobsRepository.findAll(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
+      .thenReturn(dbPage)
+
+    // When
+    val result = matchingCandidateJobRetriever.retrieveAllJobs(
+      prisonNumber = prisonNumber,
+      sectors = null,
+      releaseArea = null,
+      searchRadius = null,
+      pageable = pageable,
+      offenceExclusions = emptyList(),
+      employerId = null,
+    )
+
+    // Then
+    assertThat(result.content).hasSize(1)
+    verify(matchingCandidateJobsRepository).findAll(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+  }
+
+  private fun createJobResponse(id: String, exclusions: String) = GetMatchingCandidateJobsResponse(
+    id = id,
+    jobTitle = "Job $id",
+    employerName = "Employer",
+    sector = "Sector",
+    postcode = "S1 1AA",
+    closingDate = today.plusDays(7),
+    offenceExclusions = exclusions,
+    hasExpressedInterest = false,
+    createdAt = Instant.now(),
+    distance = 1.0f,
+    isNational = false,
+    numberOfVacancies = 1,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetrieverShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetrieverShould.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 
-import java.time.Instant
-import java.time.LocalDate
-import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,6 +18,9 @@ import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.MatchingCandidateJobRepository
+import java.time.Instant
+import java.time.LocalDate
+import java.util.stream.Stream
 
 @ExtendWith(MockitoExtension::class)
 class MatchingCandidateJobRetrieverShould : TestBase() {
@@ -107,27 +107,27 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
     val job = createJobResponse(id = "1", exclusions = jobExclusions)
 
     whenever(
-        matchingCandidateJobsRepository.findAll(
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-        ),
+      matchingCandidateJobsRepository.findAll(
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+      ),
     ).thenReturn(PageImpl(listOf(job)))
 
     // When
     val result = matchingCandidateJobRetriever.retrieveAllJobs(
-        prisonNumber = prisonNumber,
-        sectors = null,
-        releaseArea = null,
-        searchRadius = null,
-        pageable = pageable,
-        offenceExclusions = candidateExclusions,
-        employerId = null,
+      prisonNumber = prisonNumber,
+      sectors = null,
+      releaseArea = null,
+      searchRadius = null,
+      pageable = pageable,
+      offenceExclusions = candidateExclusions,
+      employerId = null,
     )
 
     // Then
@@ -146,16 +146,16 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
     val dbPage = PageImpl(listOf(job))
 
     whenever(
-        matchingCandidateJobsRepository.findAll(
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-        ),
+      matchingCandidateJobsRepository.findAll(
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+      ),
     )
       .thenReturn(dbPage)
 
@@ -173,14 +173,14 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
     // Then
     assertThat(result.content).hasSize(1)
     verify(matchingCandidateJobsRepository).findAll(
-        anyOrNull(),
-        anyOrNull(),
-        anyOrNull(),
-        anyOrNull(),
-        anyOrNull(),
-        anyOrNull(),
-        anyOrNull(),
-        anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
     )
   }
 
@@ -201,28 +201,28 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
     val dbPage = PageImpl(jobsFromDb, pageRequest, jobsFromDb.size.toLong())
 
     whenever(
-        matchingCandidateJobsRepository.findAll(
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-            anyOrNull(),
-        ),
+      matchingCandidateJobsRepository.findAll(
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+      ),
     ).thenReturn(dbPage)
 
     // When
     val result = matchingCandidateJobRetriever.retrieveAllJobs(
-        prisonNumber = prisonNumber,
-        sectors = null,
-        releaseArea = null,
-        searchRadius = null,
-        pageable = pageRequest,
-        isNationalJob = false,
-        employerId = null,
-        offenceExclusions = candidateExclusions,
+      prisonNumber = prisonNumber,
+      sectors = null,
+      releaseArea = null,
+      searchRadius = null,
+      pageable = pageRequest,
+      isNationalJob = false,
+      employerId = null,
+      offenceExclusions = candidateExclusions,
     )
 
     // Then
@@ -240,7 +240,7 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
 
     @JvmStatic
     fun exclusionPagingMetaDataTestProvider(): Stream<Arguments> = Stream.of(
-        // (Candidate Exclusions, Job Exclusions in DB, Expected IDs to remain)
+      // (Candidate Exclusions, Job Exclusions in DB, Expected IDs to remain)
 
       // Scenario: Multiple candidate exclusions vs multiple job exclusions
       Arguments.of(
@@ -249,40 +249,40 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
         listOf("2"),
       ),
       // Scenario: One match, one safe
-        Arguments.of(
-            listOf("ARSON"),
-            listOf("ARSON", "NONE"),
-            listOf("2"),
-        ),
-        // Scenario: Case insensitivity and trimming
-        Arguments.of(
-            listOf(" arson "),
-            listOf("ARSON", " murder ", "CLEAN"),
-            listOf("2", "3"),
-        ),
-        // Scenario: Empty candidate exclusions (should return everything)
-        Arguments.of(
-            emptyList<String>(),
-            listOf("ARSON", "MURDER"),
-            listOf("1", "2"),
-        ),
+      Arguments.of(
+        listOf("ARSON"),
+        listOf("ARSON", "NONE"),
+        listOf("2"),
+      ),
+      // Scenario: Case insensitivity and trimming
+      Arguments.of(
+        listOf(" arson "),
+        listOf("ARSON", " murder ", "CLEAN"),
+        listOf("2", "3"),
+      ),
+      // Scenario: Empty candidate exclusions (should return everything)
+      Arguments.of(
+        emptyList<String>(),
+        listOf("ARSON", "MURDER"),
+        listOf("1", "2"),
+      ),
     )
 
     @JvmStatic
     fun exclusionTestProvider(): Stream<Arguments> = Stream.of(
-        // candidateExclusions, jobExclusions, shouldBeFiltered
-        Arguments.of(listOf("arson"), "ARSON", true),
-        Arguments.of(listOf("arson"), " ARSON", true),
-        Arguments.of(listOf("arson"), "ARSON ", true),
-        Arguments.of(listOf(" arson "), "  ARSON  ", true),
-        Arguments.of(listOf("arson "), "  ARSON  ", true),
-        Arguments.of(listOf(" arson"), "  ARSON  ", true),
-        Arguments.of(listOf("ARSON"), "MURDER, ARSON, THEFT", true),
-        Arguments.of(listOf("MURDER"), "ARSON", false),
-        Arguments.of(listOf("DRIVING"), "DRIVING_OFFENCE", false),
-        Arguments.of(listOf("SEXUAL"), "NONE", false),
-        Arguments.of(listOf("arson", "murder"), "MURDER", true),
-        Arguments.of(listOf("ARSON"), "arson,murder", true),
+      // candidateExclusions, jobExclusions, shouldBeFiltered
+      Arguments.of(listOf("arson"), "ARSON", true),
+      Arguments.of(listOf("arson"), " ARSON", true),
+      Arguments.of(listOf("arson"), "ARSON ", true),
+      Arguments.of(listOf(" arson "), "  ARSON  ", true),
+      Arguments.of(listOf("arson "), "  ARSON  ", true),
+      Arguments.of(listOf(" arson"), "  ARSON  ", true),
+      Arguments.of(listOf("ARSON"), "MURDER, ARSON, THEFT", true),
+      Arguments.of(listOf("MURDER"), "ARSON", false),
+      Arguments.of(listOf("DRIVING"), "DRIVING_OFFENCE", false),
+      Arguments.of(listOf("SEXUAL"), "NONE", false),
+      Arguments.of(listOf("arson", "murder"), "MURDER", true),
+      Arguments.of(listOf("ARSON"), "arson,murder", true),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetrieverShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetrieverShould.kt
@@ -1,9 +1,15 @@
 package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 
+import java.time.Instant
+import java.time.LocalDate
+import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -15,8 +21,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.MatchingCandidateJobRepository
-import java.time.Instant
-import java.time.LocalDate
 
 @ExtendWith(MockitoExtension::class)
 class MatchingCandidateJobRetrieverShould : TestBase() {
@@ -77,6 +81,8 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
     // Only Job 1 and Job 4 remain
     assertThat(result.content).hasSize(2)
     assertThat(result.content.map { it.id }).containsExactly("1", "4")
+    assertThat(result.totalElements).isEqualTo(2)
+    assertThat(result.totalPages).isEqualTo(1)
 
     verify(matchingCandidateJobsRepository, times(1)).findAll(
       eq(prisonNumber),
@@ -90,28 +96,47 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
     )
   }
 
-  @Test
-  fun `retrieveAllJobs should be case insensitive and handle whitespace when filtering`() {
+  @ParameterizedTest
+  @MethodSource("exclusionTestProvider")
+  fun `retrieveAllJobs should filter jobs based on various exclusion combinations`(
+    candidateExclusions: List<String>,
+    jobExclusions: String,
+    shouldBeFiltered: Boolean,
+  ) {
     // Given
-    val offenceExclusions = listOf(" arson ") // Lowercase with space
-    val job = createJobResponse(id = "1", exclusions = "  ARSON  ") // Uppercase with space
+    val job = createJobResponse(id = "1", exclusions = jobExclusions)
 
-    whenever(matchingCandidateJobsRepository.findAll(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
-      .thenReturn(PageImpl(listOf(job)))
+    whenever(
+        matchingCandidateJobsRepository.findAll(
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+        ),
+    ).thenReturn(PageImpl(listOf(job)))
 
     // When
     val result = matchingCandidateJobRetriever.retrieveAllJobs(
-      prisonNumber = prisonNumber,
-      sectors = null,
-      releaseArea = null,
-      searchRadius = null,
-      pageable = pageable,
-      offenceExclusions = offenceExclusions,
-      employerId = null,
+        prisonNumber = prisonNumber,
+        sectors = null,
+        releaseArea = null,
+        searchRadius = null,
+        pageable = pageable,
+        offenceExclusions = candidateExclusions,
+        employerId = null,
     )
 
     // Then
-    assertThat(result.content).isEmpty()
+    if (shouldBeFiltered) {
+      assertThat(result.content).isEmpty()
+    } else {
+      assertThat(result.content).hasSize(1)
+      assertThat(result.content[0].id).isEqualTo("1")
+    }
   }
 
   @Test
@@ -120,7 +145,18 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
     val job = createJobResponse(id = "1", exclusions = "ARSON")
     val dbPage = PageImpl(listOf(job))
 
-    whenever(matchingCandidateJobsRepository.findAll(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
+    whenever(
+        matchingCandidateJobsRepository.findAll(
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+        ),
+    )
       .thenReturn(dbPage)
 
     // When
@@ -136,7 +172,118 @@ class MatchingCandidateJobRetrieverShould : TestBase() {
 
     // Then
     assertThat(result.content).hasSize(1)
-    verify(matchingCandidateJobsRepository).findAll(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+    verify(matchingCandidateJobsRepository).findAll(
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+        anyOrNull(),
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource("exclusionPagingMetaDataTestProvider")
+  fun `retrieveAllJobs should return PageImpl with correctly filtered content and metadata`(
+    candidateExclusions: List<String>,
+    jobExclusionsList: List<String?>,
+    expectedIdsRemaining: List<String>,
+  ) {
+    // Given
+    val pageRequest = PageRequest.of(0, 10)
+    val jobsFromDb = jobExclusionsList.mapIndexed { index, exclusions ->
+      createJobResponse(id = (index + 1).toString(), exclusions = exclusions ?: "")
+    }
+
+    // The repository returns the "raw" unfiltered list
+    val dbPage = PageImpl(jobsFromDb, pageRequest, jobsFromDb.size.toLong())
+
+    whenever(
+        matchingCandidateJobsRepository.findAll(
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+        ),
+    ).thenReturn(dbPage)
+
+    // When
+    val result = matchingCandidateJobRetriever.retrieveAllJobs(
+        prisonNumber = prisonNumber,
+        sectors = null,
+        releaseArea = null,
+        searchRadius = null,
+        pageable = pageRequest,
+        isNationalJob = false,
+        employerId = null,
+        offenceExclusions = candidateExclusions,
+    )
+
+    // Then
+    // 1. Verify the content contains only the expected IDs
+    assertThat(result.content.map { it.id }).containsExactlyElementsOf(expectedIdsRemaining)
+
+    // 2. Verify the Pageable metadata is preserved
+    assertThat(result.pageable).isEqualTo(pageRequest)
+
+    // 3. Verify totalElements matches the size of the filtered list (per your implementation)
+    assertThat(result.totalElements).isEqualTo(expectedIdsRemaining.size.toLong())
+  }
+
+  companion object {
+
+    @JvmStatic
+    fun exclusionPagingMetaDataTestProvider(): Stream<Arguments> = Stream.of(
+        // (Candidate Exclusions, Job Exclusions in DB, Expected IDs to remain)
+
+      // Scenario: Multiple candidate exclusions vs multiple job exclusions
+      Arguments.of(
+        listOf("ARSON", "THEFT"),
+        listOf("MURDER, ARSON", "DRIVING", "THEFT, FRAUD"),
+        listOf("2"),
+      ),
+      // Scenario: One match, one safe
+        Arguments.of(
+            listOf("ARSON"),
+            listOf("ARSON", "NONE"),
+            listOf("2"),
+        ),
+        // Scenario: Case insensitivity and trimming
+        Arguments.of(
+            listOf(" arson "),
+            listOf("ARSON", " murder ", "CLEAN"),
+            listOf("2", "3"),
+        ),
+        // Scenario: Empty candidate exclusions (should return everything)
+        Arguments.of(
+            emptyList<String>(),
+            listOf("ARSON", "MURDER"),
+            listOf("1", "2"),
+        ),
+    )
+
+    @JvmStatic
+    fun exclusionTestProvider(): Stream<Arguments> = Stream.of(
+        // candidateExclusions, jobExclusions, shouldBeFiltered
+        Arguments.of(listOf("arson"), "ARSON", true),
+        Arguments.of(listOf("arson"), " ARSON", true),
+        Arguments.of(listOf("arson"), "ARSON ", true),
+        Arguments.of(listOf(" arson "), "  ARSON  ", true),
+        Arguments.of(listOf("arson "), "  ARSON  ", true),
+        Arguments.of(listOf(" arson"), "  ARSON  ", true),
+        Arguments.of(listOf("ARSON"), "MURDER, ARSON, THEFT", true),
+        Arguments.of(listOf("MURDER"), "ARSON", false),
+        Arguments.of(listOf("DRIVING"), "DRIVING_OFFENCE", false),
+        Arguments.of(listOf("SEXUAL"), "NONE", false),
+        Arguments.of(listOf("arson", "murder"), "MURDER", true),
+        Arguments.of(listOf("ARSON"), "arson,murder", true),
+    )
   }
 
   private fun createJobResponse(id: String, exclusions: String) = GetMatchingCandidateJobsResponse(


### PR DESCRIPTION
- Update `MatchingCandidateJobRepository` to return `offenceExclusions`
- Update `GetMatchingCandidateJobsResponse` to include `offenceExclusions`
- Update `MatchingCandidateJobRetriever` to include job filtering based on `offenceExclusions` when present.
- Add test coverage for `MatchingCandidateJobRetriever`
- Add integration test coverage.