### PR TITLE
ESWE-1738: Translate query of matching-candidate to jobs

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.GetJobsClosin
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.GetMatchingCandidateJobsResponse
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ArchivedRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.CALC_DISTANCE_EXPRESSION
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.CALC_DISTANCE_EXPRESSION_NATIVE
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.ExpressionOfInterestRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.Job
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.MatchingCandidateJobRepository
@@ -43,14 +44,19 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
   private val defaultPageable = PageRequest.of(0, 10, defaultSort)
   private val closingSoonPageable = PageRequest.of(0, 5, defaultSort)
   private val paginatedSortByClosingDateAsc = PageRequest.of(0, 20, defaultSort)
-  private val sortByDistanceAndJobTitle =
-    CALC_DISTANCE_EXPRESSION.let { JpaSort.unsafe(Sort.Direction.ASC, it, "title") }
-  private val paginatedSortByDistanceAsc = PageRequest.of(0, 20, sortByDistanceAndJobTitle)
+  private val paginatedSortByDistanceAsc = PageRequest.of(0, 20, CALC_DISTANCE_EXPRESSION.let { JpaSort.unsafe(Sort.Direction.ASC, it, "title") })
+  private val paginatedSortByDistanceAscNative = PageRequest.of(0, 20, CALC_DISTANCE_EXPRESSION_NATIVE.let { JpaSort.unsafe(Sort.Direction.ASC, it, "title") })
   private val today = LocalDate.of(2024, 10, 1)
 
   @Nested
   @DisplayName("Given no job has been created")
   inner class GivenNoJob {
+    @Test
+    fun `retrieve an empty list of matched jobs`() {
+      val results = matchingCandidateJobRepository.findAllJobs(prisonNumber, currentDate = today, pageable = defaultPageable)
+      assertThat(results).isEmpty()
+    }
+
     @Test
     fun `retrieve an empty list of matched jobs closing soon`() {
       val results = matchingCandidateJobRepository.findJobsClosingSoon(prisonNumber, null, today, closingSoonPageable)
@@ -79,7 +85,9 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
   @Nested
   @DisplayName("Given some jobs have been created")
   inner class GivenSomeJobsCreated {
-    private val allJobs = listOf(amazonForkliftOperator, tescoWarehouseHandler, abcConstructionApprentice, abcNationalConstructionApprentice, amazonNationalForkliftOperator)
+    private val jobs = listOf(amazonForkliftOperator, tescoWarehouseHandler, abcConstructionApprentice)
+    private val nationalJobs = listOf(abcNationalConstructionApprentice, amazonNationalForkliftOperator)
+    private val allJobs = jobs + nationalJobs
 
     @BeforeEach
     fun setUp() {
@@ -91,6 +99,22 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
       assertFindJobsClosingSoonIsExpected(
         expectedSize = allJobs.size,
         expectedJobs = allJobs,
+      )
+    }
+
+    @Test
+    fun `retrieve matched jobs`() {
+      assertFindAllJobsIsExpected(
+        expectedSize = jobs.size,
+        expectedJobs = jobs,
+      )
+    }
+
+    @Test
+    fun `retrieve matched national jobs`() {
+      assertFindAllJobsIsExpected(
+        expectedJobs = nationalJobs,
+        isNationalJob = true,
       )
     }
 
@@ -459,6 +483,50 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
     @Nested
     @DisplayName("And custom filter or parameter has been specified")
     inner class AndCustomisation {
+      private val onPage2 = PageRequest.of(1, 1, defaultSort)
+
+      @Test
+      fun `retrieve matched jobs sorted by distance`() {
+        val releaseArea = amazonForkliftOperator.postcode
+        val searchRadius = 50
+        // distances: 0 for amazonForkliftOperator, 1.9 for abcConstructionApprentice, 19.1 for tescoWarehouseHandler
+        val expectedJobs = listOf(amazonForkliftOperator, abcConstructionApprentice, tescoWarehouseHandler)
+
+        assertFindAllJobsIsExpected(
+          expectedSize = expectedJobs.size,
+          expectedJobs = expectedJobs,
+          location = releaseArea,
+          searchRadius = searchRadius,
+          pageable = paginatedSortByDistanceAscNative,
+        )
+      }
+
+      @Test
+      fun `retrieve matched jobs sorted by job title`() {
+        val paginatedSortByJobTitle = PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "title"))
+        // job titles: Apprentice plasterer (ABC), Forklift operator (Amazon) then Warehouse handler (Tesco)
+        val expectedJobs = listOf(abcConstructionApprentice, amazonForkliftOperator, tescoWarehouseHandler)
+        assertFindAllJobsIsExpected(
+          expectedSize = expectedJobs.size,
+          expectedJobs = expectedJobs,
+          pageable = paginatedSortByJobTitle,
+        )
+      }
+
+      @Test
+      fun `retrieve specific page of matched jobs`() {
+        // verify that pagination "skip" (discard by offsetting) national jobs, and results are properly paginated
+        val expectedJobs = listOf(jobs[1])
+        assertFindAllJobsIsExpected(expectedJobs = expectedJobs, pageable = onPage2)
+      }
+
+      @Test
+      fun `retrieve specific page of matched national jobs`() {
+        // verify that pagination "skip" (discard by offsetting) non-national jobs, and results are properly paginated
+        val expectedJobs = listOf(nationalJobs[1])
+        assertFindAllJobsIsExpected(isNationalJob = true, expectedJobs = expectedJobs, pageable = onPage2)
+      }
+
       @Test
       fun `retrieve matched jobs closing soon, of specified sectors only`() {
         val sectors = listOf(tescoWarehouseHandler.sector, amazonForkliftOperator.sector, amazonNationalForkliftOperator.sector).map { it.lowercase() }
@@ -553,7 +621,7 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
       givenPrisonNumber: String = prisonNumber,
       sectors: List<String>? = null,
       location: String? = null,
-      searchRadius: Int = 50,
+      searchRadius: Int? = null,
       currentDate: LocalDate = today,
       isNationalJob: Boolean = false,
       employerId: String? = null,
@@ -561,14 +629,14 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
       expectedSize: Int? = null,
       expectedJobs: List<Job>? = null,
     ) {
-      val results = matchingCandidateJobRepository.findAll(givenPrisonNumber, sectors, location, searchRadius, currentDate, isNationalJob, employerId, pageable)
+      val results = matchingCandidateJobRepository.findAllJobs(givenPrisonNumber, sectors, location, searchRadius, currentDate, isNationalJob, employerId, pageable)
 
       expectedSize?.let {
         assertThat(results).hasSize(expectedSize)
       }
       expectedJobs?.let {
         val expectedResults = expectedJobs.map { it.listResponse() }
-        assertThat(results.content).usingRecursiveComparison().ignoringFields("createdAt").isEqualTo(expectedResults)
+        assertThat(results.content).usingRecursiveComparison().ignoringFields("createdAt", "distance").isEqualTo(expectedResults)
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/audit/domain/AuditedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/audit/domain/AuditedEntity.kt
@@ -21,10 +21,10 @@ abstract class AuditedEntity(
   var lastModifiedBy: String? = null,
 
   @CreatedDate
-  @Column(name = "created_at", nullable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "timestamp")
   var createdAt: Instant? = null,
 
   @LastModifiedDate
-  @Column(name = "last_modified_at", nullable = false, updatable = true)
+  @Column(name = "last_modified_at", nullable = false, updatable = true, columnDefinition = "timestamp")
   var lastModifiedAt: Instant? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -160,7 +160,7 @@ class JobsGet(
     val direction = if (sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
     val sortedBy = when (sortBy) {
       "jobTitle" -> Sort.by(direction, "title")
-      "distance" -> matchingCandidateJobRetriever.sortByDistance(direction)
+      "distance" -> matchingCandidateJobRetriever.sortByDistanceOfNativeQuery(direction)
       else -> Sort.by(direction, sortBy!!)
     }
     val lowerCaseSectors = sectors?.map { it.lowercase() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetMatchingCandidateJobsResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/GetMatchingCandidateJobsResponse.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application
 
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 
 data class GetMatchingCandidateJobsResponse(
   val id: String,
@@ -15,4 +16,18 @@ data class GetMatchingCandidateJobsResponse(
   val distance: Float?,
   val isNational: Boolean = false,
   val numberOfVacancies: Int,
-)
+) {
+  constructor(dto: MatchingCandidateJobsDTO) : this(
+    id = dto.id,
+    jobTitle = dto.jobTitle,
+    employerName = dto.employerName,
+    sector = dto.sector,
+    postcode = dto.postcode,
+    closingDate = dto.closingDate,
+    hasExpressedInterest = dto.hasExpressedInterest,
+    createdAt = dto.createdAt?.atZone(ZoneId.systemDefault())?.toInstant(),
+    distance = dto.distance,
+    isNational = dto.isNational,
+    numberOfVacancies = dto.numberOfVacancies,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
@@ -8,9 +8,11 @@ import org.springframework.data.domain.Sort.Direction
 import org.springframework.data.jpa.domain.JpaSort
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.CALC_DISTANCE_EXPRESSION
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.CALC_DISTANCE_EXPRESSION_NATIVE
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.domain.MatchingCandidateJobRepository
 import uk.gov.justice.digital.hmpps.jobsboard.api.time.TimeProvider
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 class MatchingCandidateJobRetriever(
@@ -38,7 +40,8 @@ class MatchingCandidateJobRetriever(
       maybeRevisedReleaseAreaInput = null
     }
 
-    return matchingCandidateJobsRepository.findAll(prisonNumber, sectors, maybeRevisedReleaseAreaInput, maybeRevisedSearchRadiusInput, today, isNationalJob, employerId, pageable)
+    return matchingCandidateJobsRepository.findAllJobs(prisonNumber, sectors, maybeRevisedReleaseAreaInput, maybeRevisedSearchRadiusInput, today, isNationalJob, employerId, pageable)
+      .map { it.response() }
   }
 
   fun retrieveClosingJobs(prisonNumber: String, sectors: List<String>?, size: Int): List<GetJobsClosingSoonResponse> = PageRequest.of(0, size).let { limitedBySize ->
@@ -81,4 +84,21 @@ class MatchingCandidateJobRetriever(
   }
 
   fun sortByDistance(direction: Direction = Direction.ASC): Sort = JpaSort.unsafe(direction, CALC_DISTANCE_EXPRESSION)
+  fun sortByDistanceOfNativeQuery(direction: Direction = Direction.ASC): Sort = JpaSort.unsafe(direction, CALC_DISTANCE_EXPRESSION_NATIVE)
+}
+
+data class MatchingCandidateJobsDTO(
+  val id: String,
+  val jobTitle: String,
+  val employerName: String,
+  val sector: String,
+  val postcode: String? = null,
+  val closingDate: LocalDate? = null,
+  val hasExpressedInterest: Boolean = false,
+  val createdAt: LocalDateTime? = null,
+  val distance: Float?,
+  val isNational: Boolean = false,
+  val numberOfVacancies: Int,
+) {
+  fun response() = GetMatchingCandidateJobsResponse(this)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Archived.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Archived.kt
@@ -26,7 +26,7 @@ data class Archived(
   var createdBy: String? = null,
 
   @CreatedDate
-  @Column(name = "created_at", nullable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "timestamp")
   var createdAt: Instant? = null,
 
   @ManyToOne

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Auditable.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/Auditable.kt
@@ -22,10 +22,10 @@ abstract class Auditable {
   var lastModifiedBy: String? = null
 
   @CreatedDate
-  @Column(name = "created_at", nullable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "timestamp")
   var createdAt: Instant? = null
 
   @LastModifiedDate
-  @Column(name = "last_modified_at", nullable = false, updatable = true)
+  @Column(name = "last_modified_at", nullable = false, updatable = true, columnDefinition = "timestamp")
   var lastModifiedAt: Instant? = null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ExpressionOfInterest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/ExpressionOfInterest.kt
@@ -27,7 +27,7 @@ data class ExpressionOfInterest(
   var createdBy: String? = null,
 
   @CreatedDate
-  @Column(name = "created_at", nullable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "timestamp")
   var createdAt: Instant? = null,
 
   @MapsId("id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -80,7 +80,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
   /**
    * Find all jobs
    *
-   * notes: This trick will break if `sectors` cam contain a `DUMMY` value
+   * notes: This trick will break if `sectors` can contain an empty string ""
    */
   fun findAllJobs(
     prisonNumber: String,
@@ -93,7 +93,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     pageable: Pageable,
   ) = findAllJobs(
     prisonNumber = prisonNumber,
-    sectors = if (sectors.isNullOrEmpty()) listOf("DUMMY") else sectors,
+    sectors = if (sectors.isNullOrEmpty()) listOf("") else sectors,
     applySectorsFilter = !sectors.isNullOrEmpty(),
     releaseArea = releaseArea,
     searchRadius = searchRadius,
@@ -138,7 +138,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
   )
   fun findAllJobs(
     @Param("prisonNumber") prisonNumber: String,
-    @Param("sectors") sectors: List<String> = listOf("DUMMY"),
+    @Param("sectors") sectors: List<String> = listOf(""),
     @Param("applySectorsFilter") applySectorsFilter: Boolean = false,
     @Param("releaseArea") releaseArea: String? = null,
     @Param("searchRadius") searchRadius: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -10,13 +10,16 @@ import uk.gov.justice.digital.hmpps.jobsboard.api.entity.EntityId
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.GetJobsClosingSoonResponse
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.GetMatchingCandidateJobResponse
 import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.GetMatchingCandidateJobsResponse
+import uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.MatchingCandidateJobsDTO
 import java.time.LocalDate
 
 const val CALC_DISTANCE_EXPRESSION = "CAST(ROUND(SQRT(POWER(pos2.xCoordinate - pos1.xCoordinate, 2) + POWER(pos2.yCoordinate - pos1.yCoordinate, 2)) / 1609.34, 1) AS FLOAT)"
+const val CALC_DISTANCE_EXPRESSION_NATIVE = "CAST(ROUND(CAST(SQRT(POWER(pos2.x_coordinate - pos1.x_coordinate, 2) + POWER(pos2.y_coordinate - pos1.y_coordinate, 2)) / 1609.34 AS NUMERIC), 1) as REAL)"
 
 @Repository
 interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
 
+  @Deprecated(level = DeprecationLevel.ERROR, message = "This query has been deprecated.", replaceWith = ReplaceWith("findAllJobs(prisonNumber, sectors, releaseArea, searchRadius, currentDate, isNationalJob, employerId, pageable)"))
   @Query(
     """
     SELECT new uk.gov.justice.digital.hmpps.jobsboard.api.jobs.application.GetMatchingCandidateJobsResponse(
@@ -73,6 +76,77 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     @Param("employerId") employerId: String? = null,
     pageable: Pageable,
   ): Page<GetMatchingCandidateJobsResponse>
+
+  /**
+   * Find all jobs
+   *
+   * notes: This trick will break if `sectors` cam contain a `DUMMY` value
+   */
+  fun findAllJobs(
+    prisonNumber: String,
+    sectors: List<String>? = null,
+    releaseArea: String? = null,
+    searchRadius: Int? = null,
+    currentDate: LocalDate,
+    isNationalJob: Boolean? = null,
+    employerId: String? = null,
+    pageable: Pageable,
+  ) = findAllJobs(
+    prisonNumber = prisonNumber,
+    sectors = if (sectors.isNullOrEmpty()) listOf("DUMMY") else sectors,
+    applySectorsFilter = !sectors.isNullOrEmpty(),
+    releaseArea = releaseArea,
+    searchRadius = searchRadius,
+    currentDate = currentDate,
+    isNationalJob = isNationalJob,
+    employerId = employerId,
+    pageable = pageable,
+  )
+
+  @Query(
+    """
+    SELECT 
+      j.id,
+      j.title as jobTitle,
+      e.name as employerName,
+      j.sector,
+      j.postcode,
+      j.closing_date as closingDate,
+      CASE WHEN eoi.created_at IS NOT NULL THEN true ELSE false END as hasExpressedInterest,
+      j.created_at as createdAt,
+      CAST(ROUND(CAST(SQRT(POWER(pos2.x_coordinate - pos1.x_coordinate, 2) + POWER(pos2.y_coordinate - pos1.y_coordinate, 2)) / 1609.34 AS NUMERIC), 1) as REAL) as distance,
+      j.is_national as isNational,
+      j.number_of_vacancies as numberOfVacancies
+    FROM jobs j
+    LEFT JOIN jobs_expressions_of_interest eoi ON eoi.job_id = j.id AND eoi.prison_number = :prisonNumber
+    LEFT JOIN employers e ON j.employer_id = e.id
+    LEFT JOIN jobs_archived a ON a.job_id = j.id AND a.prison_number = :prisonNumber
+    LEFT JOIN postcodes pos1 ON j.postcode = pos1.code
+    LEFT JOIN postcodes pos2 ON pos2.code = :releaseArea
+    WHERE  (j.closing_date >= :currentDate OR j.closing_date IS NULL)
+    AND (NOT :applySectorsFilter OR LOWER(j.sector) IN :sectors)
+    AND a.job_id IS NULL
+    AND (
+      :isNationalJob IS TRUE      
+      OR COALESCE(:searchRadius, 0) <= 0
+      OR (pos1.x_coordinate IS NOT NULL AND pos1.y_coordinate IS NOT NULL AND COALESCE(ROUND(CAST(SQRT(POWER(pos2.x_coordinate - pos1.x_coordinate, 2) + POWER(pos2.y_coordinate - pos1.y_coordinate, 2)) / 1609.34 AS NUMERIC), 1), -1) <= :searchRadius)
+    )
+    AND (j.is_national = :isNationalJob OR :isNationalJob IS NULL)
+    AND (e.id = :employerId OR :employerId IS NULL)
+    """,
+    nativeQuery = true,
+  )
+  fun findAllJobs(
+    @Param("prisonNumber") prisonNumber: String,
+    @Param("sectors") sectors: List<String> = listOf("DUMMY"),
+    @Param("applySectorsFilter") applySectorsFilter: Boolean = false,
+    @Param("releaseArea") releaseArea: String? = null,
+    @Param("searchRadius") searchRadius: Int? = null,
+    @Param("currentDate") currentDate: LocalDate,
+    @Param("isNationalJob") isNationalJob: Boolean? = null,
+    @Param("employerId") employerId: String? = null,
+    pageable: Pageable,
+  ): Page<MatchingCandidateJobsDTO>
 
   @Query(
     """


### PR DESCRIPTION
Prepare for next change of offence exclusions filter

- Translate matching candidate query to native (from JPQL)
- Add DTO `MatchingCandidateJobsDTO` at query results (of `findAllJobs(...)`), convert back to API response afterward; This is for compatibility of `Instant` vs `LocalDateTime` around JPA.
- Revise `columnDefinition` of Entity for repository tests with JPA `ddl-auto` of integration tests
- Add test cases to repository test