### PR TITLE
ESWE-1738: Offence exclusions filter at matching candidate

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/MatchingCandidateGetShould.kt
@@ -469,6 +469,43 @@ class MatchingCandidateGetShould : MatchingCandidateTestCase() {
         }
       }
     }
+
+    @Nested
+    @DisplayName("And offence exclusions have been provided")
+    inner class AndOffenceExclusionsHaveBeenProvided {
+      private val offenceExclusions = listOf("DRIVING", "MURDER").joinToString()
+
+      @BeforeEach
+      fun setUp() {
+        requestParams.append("&offenceExclusions=$offenceExclusions")
+      }
+
+      @Test
+      fun `return Jobs list, without jobs of specified offence exclusions`() {
+        // amazonForkliftOperator shall be excluded (DRIVING)
+        val expectedResponse = listOf(
+          abcConstructionApprentice,
+          tescoWarehouseHandler,
+          asdaWarehouseHandlerNonGeoCoded,
+        ).map { builder().from(it).withDistanceInMiles(null).buildCandidateMatchingListItemResponseBody() }
+          .let { expectedResponseListOf(*it.toTypedArray()) }
+
+        assertGetMatchingCandidateJobsIsOK(parameters = requestParams.toString(), expectedResponse = expectedResponse)
+      }
+
+      @Test
+      fun `return National Jobs list, without jobs of specified offence exclusions`() {
+        // amazonNationalForkliftOperator shall be excluded (DRIVING)
+        requestParams.append("&isNationalJob=true")
+        val expectedResponse = expectedResponseListOf(
+          builder().from(abcNationalConstructionApprentice)
+            .withDistanceInMiles(null)
+            .buildCandidateMatchingListItemResponseBody(),
+        )
+
+        assertGetMatchingCandidateJobsIsOK(parameters = requestParams.toString(), expectedResponse = expectedResponse)
+      }
+    }
   }
 
   @Nested

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/infrastructure/MatchingCandidateJobRepositoryShould.kt
@@ -528,6 +528,27 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
       }
 
       @Test
+      fun `retrieve matched jobs, with specific offence exclusions`() {
+        // offenceExclusions: Arson, Driving offences, Murder, Sexual offences, Terrorism
+        // - options: ARSON,DRIVING,MURDER,SEXUAL,TERRORISM
+        // - not options: NONE, OTHER, CASE_BY_CASE
+        // ============================================================
+        // - amazonForkliftOperator:    "NONE,DRIVING,OTHER"
+        // - tescoWarehouseHandler:     "CASE_BY_CASE,OTHER"
+        // - abcConstructionApprentice: "CASE_BY_CASE,OTHER"
+        val offenceExclusions = listOf("DRIVING", "MURDER")
+        val expectedJobs = listOf(tescoWarehouseHandler, abcConstructionApprentice)
+        assertFindAllJobsIsExpected(expectedJobs = expectedJobs, offenceExclusions = offenceExclusions)
+      }
+
+      @Test
+      fun `retrieve specific page of matched jobs, with specific offence exclusions`() {
+        val offenceExclusions = listOf("DRIVING")
+        val expectedJobs = listOf(abcConstructionApprentice)
+        assertFindAllJobsIsExpected(expectedJobs = expectedJobs, offenceExclusions = offenceExclusions, pageable = onPage2)
+      }
+
+      @Test
       fun `retrieve matched jobs closing soon, of specified sectors only`() {
         val sectors = listOf(tescoWarehouseHandler.sector, amazonForkliftOperator.sector, amazonNationalForkliftOperator.sector).map { it.lowercase() }
         val expectedJobs = listOf(amazonForkliftOperator, tescoWarehouseHandler, amazonNationalForkliftOperator)
@@ -625,11 +646,22 @@ class MatchingCandidateJobRepositoryShould : JobRepositoryTestCase() {
       currentDate: LocalDate = today,
       isNationalJob: Boolean = false,
       employerId: String? = null,
+      offenceExclusions: List<String>? = null,
       pageable: Pageable = defaultPageable,
       expectedSize: Int? = null,
       expectedJobs: List<Job>? = null,
     ) {
-      val results = matchingCandidateJobRepository.findAllJobs(givenPrisonNumber, sectors, location, searchRadius, currentDate, isNationalJob, employerId, pageable)
+      val results = matchingCandidateJobRepository.findAllJobs(
+        prisonNumber = givenPrisonNumber,
+        sectors = sectors,
+        releaseArea = location,
+        searchRadius = searchRadius,
+        currentDate = currentDate,
+        isNationalJob = isNationalJob,
+        employerId = employerId,
+        offenceExclusions = offenceExclusions,
+        pageable = pageable,
+      )
 
       expectedSize?.let {
         assertThat(results).hasSize(expectedSize)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/jobs/JobsGet.kt
@@ -156,6 +156,8 @@ class JobsGet(
     isNationalJob: Boolean,
     @RequestParam(required = false)
     employerId: String?,
+    @RequestParam(required = false)
+    offenceExclusions: List<String>? = null,
   ): ResponseEntity<Page<GetMatchingCandidateJobsResponse>> {
     val direction = if (sortOrder.equals("desc", ignoreCase = true)) DESC else ASC
     val sortedBy = when (sortBy) {
@@ -165,7 +167,7 @@ class JobsGet(
     }
     val lowerCaseSectors = sectors?.map { it.lowercase() }
     val pageable: Pageable = PageRequest.of(page, size, sortedBy)
-    val jobList = matchingCandidateJobRetriever.retrieveAllJobs(prisonNumber, lowerCaseSectors, releaseArea, searchRadius, pageable, isNationalJob, employerId)
+    val jobList = matchingCandidateJobRetriever.retrieveAllJobs(prisonNumber, lowerCaseSectors, releaseArea, searchRadius, pageable, isNationalJob, employerId, offenceExclusions)
     return ResponseEntity.ok(jobList)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/application/MatchingCandidateJobRetriever.kt
@@ -30,6 +30,7 @@ class MatchingCandidateJobRetriever(
     pageable: Pageable,
     isNationalJob: Boolean? = false,
     employerId: String?,
+    offenceExclusions: List<String>?,
   ): Page<GetMatchingCandidateJobsResponse> {
     releaseArea?.let { postcodeLocationService.save(it) }
     var maybeRevisedSearchRadiusInput = searchRadius
@@ -40,7 +41,7 @@ class MatchingCandidateJobRetriever(
       maybeRevisedReleaseAreaInput = null
     }
 
-    return matchingCandidateJobsRepository.findAllJobs(prisonNumber, sectors, maybeRevisedReleaseAreaInput, maybeRevisedSearchRadiusInput, today, isNationalJob, employerId, pageable)
+    return matchingCandidateJobsRepository.findAllJobs(prisonNumber, sectors, maybeRevisedReleaseAreaInput, maybeRevisedSearchRadiusInput, today, isNationalJob, employerId, offenceExclusions, pageable)
       .map { it.response() }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/jobs/domain/MatchingCandidateJobRepository.kt
@@ -80,7 +80,7 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
   /**
    * Find all jobs
    *
-   * notes: This trick will break if `sectors` can contain an empty string ""
+   * notes: This trick will break if `sectors` or `offenceExclusions` can contain an empty string ""
    */
   fun findAllJobs(
     prisonNumber: String,
@@ -90,18 +90,24 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     currentDate: LocalDate,
     isNationalJob: Boolean? = null,
     employerId: String? = null,
+    offenceExclusions: List<String>? = null,
     pageable: Pageable,
   ) = findAllJobs(
     prisonNumber = prisonNumber,
-    sectors = if (sectors.isNullOrEmpty()) listOf("") else sectors,
+    sectors = sectors.nonEmptyList(),
     applySectorsFilter = !sectors.isNullOrEmpty(),
     releaseArea = releaseArea,
     searchRadius = searchRadius,
     currentDate = currentDate,
     isNationalJob = isNationalJob,
     employerId = employerId,
+    offenceExclusions = offenceExclusions.nonEmptyList(),
+    applyOffenceExclusionsFilter = !offenceExclusions.isNullOrEmpty(),
     pageable = pageable,
   )
+
+  // notes: This trick will break if the nullable list can contain an empty string ""
+  private fun List<String>?.nonEmptyList(): List<String> = if (this.isNullOrEmpty()) listOf("") else this
 
   @Query(
     """
@@ -133,6 +139,11 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     )
     AND (j.is_national = :isNationalJob OR :isNationalJob IS NULL)
     AND (e.id = :employerId OR :employerId IS NULL)
+    AND (
+      NOT :applyOffenceExclusionsFilter OR 
+      j.offence_exclusions = 'NONE' OR
+      NOT EXISTS (SELECT 1 FROM unnest(string_to_array(j.offence_exclusions, ',')) oe WHERE oe IN (:offenceExclusions))
+    )
     """,
     nativeQuery = true,
   )
@@ -145,6 +156,8 @@ interface MatchingCandidateJobRepository : JpaRepository<Job, EntityId> {
     @Param("currentDate") currentDate: LocalDate,
     @Param("isNationalJob") isNationalJob: Boolean? = null,
     @Param("employerId") employerId: String? = null,
+    @Param("offenceExclusions") offenceExclusions: List<String> = listOf(""),
+    @Param("applyOffenceExclusionsFilter") applyOffenceExclusionsFilter: Boolean = false,
     pageable: Pageable,
   ): Page<MatchingCandidateJobsDTO>
 


### PR DESCRIPTION
- Use `NOT EXISTS` instead of array-overlap `&&`, due to difficulty JPA passing array parameter (`text[]`); This is a slower alternative
- Specialize for `NONE` (skip checking further with array function)