### PR TITLE
ESWE-2038: Update dependencies, Helm charts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,10 +6,11 @@ plugins {
   id("jacoco")
 }
 
-ext["postgresql.version"] = "42.7.11"
+ext["postgresql.version"] = "42.7.12"
 ext["jackson-2-bom.version"] = "2.21.5"
 ext["log4j2.version"] = "2.25.5"
 ext["tomcat.version"] = "11.0.24"
+ext["httpcore5.version"] = "5.4.3"
 
 dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.5.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,19 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.7"
   kotlin("plugin.spring") version "2.4.0"
-  kotlin("plugin.jpa") version "2.3.21"
+  kotlin("plugin.jpa") version "2.4.0"
   id("jvm-test-suite")
   id("jacoco")
 }
 
 ext["postgresql.version"] = "42.7.11"
+ext["jackson-2-bom.version"] = "2.21.5"
+ext["log4j2.version"] = "2.25.5"
+ext["tomcat.version"] = "11.0.24"
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.2.0")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.5.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.4.0")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-flyway")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
@@ -22,8 +25,8 @@ dependencies {
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
   runtimeOnly("org.postgresql:postgresql")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-lib:2.4.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.5.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-lib:2.6.2")
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("io.mockk:mockk:1.14.9")
@@ -44,8 +47,8 @@ testing {
       useJUnitJupiter()
       dependencies {
         kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
-        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
-        implementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.4.0")
+        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.5.0")
+        implementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.6.2")
         implementation("org.springframework.boot:spring-boot-starter-test")
         implementation("org.mockito.kotlin:mockito-kotlin:6.3.0")
         implementation("org.wiremock:wiremock-standalone:3.13.2")

--- a/helm_deploy/hmpps-jobs-board-api/Chart.yaml
+++ b/helm_deploy/hmpps-jobs-board-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-jobs-board-api
 version: 0.2.1
 dependencies:
   - name: generic-service
-    version: "3.12"
+    version: "3.17.2"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.17"
+    version: "1.17.1"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/sar/SubjectAccessRequestApiTest.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboard/api/controller/sar/SubjectAccessRequestApiTest.kt
@@ -78,7 +78,7 @@ class SubjectAccessRequestApiTest {
       getSarHelper().stubFindLocationNameByNomisIdWith("PROPERTY BOX 1")
       getSarHelper().stubFindLocationNameByDpsIdWith("PROPERTY BOX 2")
       val dataResponse =
-        getSarHelper().requestSarData(getPrn(), getCrn(), getFromDate(), getToDate(), getWebTestClientInstance())
+        getSarHelper().requestSarData(getPrn(), getCrn(), getFromDate(), getToDate(), getWebTestClientInstance(), getContentType())
       val templateResponse = getSarHelper().requestSarTemplate(getWebTestClientInstance())
 
       val renderResult = getSarHelper().renderServiceReport(


### PR DESCRIPTION
Update these:
- Gradle SB plugin `10.5.7`
- Kotlin lib `2.5.0`
- Helm charts
  - generic-service `3.17.2`
  - generic-prometheus-alerts `1.17.1`

Pin these:
- Jackson2 `2.21.5`
- log4j `2.25.5`
- tomcat `11.0.24`
- postgresql `42.7.12`
- httpcore5 `5.4.3`

More
- Kotlin JPA plugin `2.4.0` (align with Kotlin version)
- SAR lib `2.6.2`
- SQS lib `7.4.0`